### PR TITLE
Deployment: Smithery config

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - gcpOauthKeysPath
+      - credentialsPath
+    properties:
+      gcpOauthKeysPath:
+        type: string
+        description: Path to the GCP OAuth keys JSON file
+      credentialsPath:
+        type: string
+        description: Path to the stored credentials JSON file
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command:'node',args:['dist/index.js'],env:{GMAIL_OAUTH_PATH:config.gcpOauthKeysPath, GMAIL_CREDENTIALS_PATH:config.credentialsPath}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over SSE so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@gongrzhe/server-gmail-autoauth-mcp?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂