### PR TITLE
feat: add email thread support - Add threadId and inReplyTo fields to…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,8 @@ const SendEmailSchema = z.object({
     body: z.string().describe("Email body content"),
     cc: z.array(z.string()).optional().describe("List of CC recipients"),
     bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
+    threadId: z.string().optional().describe("Thread ID to reply to"),
+    inReplyTo: z.string().optional().describe("Message ID being replied to"),
 });
 
 const ReadEmailSchema = z.object({
@@ -315,12 +317,25 @@ async function main() {
                 .replace(/\//g, '_')
                 .replace(/=+$/, '');
 
+            // Define the type for messageRequest
+            interface GmailMessageRequest {
+                raw: string;
+                threadId?: string;
+            }
+
+            const messageRequest: GmailMessageRequest = {
+                raw: encodedMessage,
+            };
+
+            // Add threadId if specified
+            if (validatedArgs.threadId) {
+                messageRequest.threadId = validatedArgs.threadId;
+            }
+
             if (action === "send") {
                 const response = await gmail.users.messages.send({
                     userId: 'me',
-                    requestBody: {
-                        raw: encodedMessage,
-                    },
+                    requestBody: messageRequest,
                 });
                 return {
                     content: [
@@ -334,9 +349,7 @@ async function main() {
                 const response = await gmail.users.drafts.create({
                     userId: 'me',
                     requestBody: {
-                        message: {
-                            raw: encodedMessage,
-                        },
+                        message: messageRequest,
                     },
                 });
                 return {

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -31,6 +31,9 @@ export function createEmailMessage(validatedArgs: any): string {
         validatedArgs.cc ? `Cc: ${validatedArgs.cc.join(', ')}` : '',
         validatedArgs.bcc ? `Bcc: ${validatedArgs.bcc.join(', ')}` : '',
         `Subject: ${encodedSubject}`,
+        // Add thread-related headers if specified
+        validatedArgs.inReplyTo ? `In-Reply-To: ${validatedArgs.inReplyTo}` : '',
+        validatedArgs.inReplyTo ? `References: ${validatedArgs.inReplyTo}` : '',
         'MIME-Version: 1.0',
         'Content-Type: text/plain; charset=UTF-8',
         'Content-Transfer-Encoding: 7bit',


### PR DESCRIPTION
# Add Email Thread Support

This PR adds support for email threading functionality to the Gmail MCP Server.

## Changes
- Add `threadId` and `inReplyTo` fields to SendEmailSchema
- Add thread-related email headers (In-Reply-To, References)
- Enable thread ID specification when sending emails

## Implementation Details
- Added proper type definitions for thread-related requests
- Updated email message creation to include thread headers
- Modified message sending logic to handle thread IDs

## Testing
Please test the following scenarios:
1. Sending a new email in a thread
2. Creating a draft reply in a thread
3. Verifying thread headers in sent messages

## Reference
Implementation based on [Gmail API Thread Guide](https://developers.google.com/workspace/gmail/api/guides/threads)