### PR TITLE
feat: include thread ID in email content 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -416,6 +416,7 @@ async function main() {
                     const from = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
                     const to = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
                     const date = headers.find(h => h.name?.toLowerCase() === 'date')?.value || '';
+                    const threadId = response.data.threadId || '';
 
                     // Extract email content using the recursive function
                     const { text, html } = extractEmailContent(response.data.payload as GmailMessagePart || {});
@@ -461,7 +462,7 @@ async function main() {
                         content: [
                             {
                                 type: "text",
-                                text: `Subject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
+                                text: `Thread ID: ${threadId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
                             },
                         ],
                     };


### PR DESCRIPTION
## Overview
The Gmail API's read_email response was missing the threadId, which prevented the proper functioning of the email reply feature. This PR adds the threadId to the response to enable proper thread-based email replies.

## Changes
- Added threadId field to read_email response