### PR TITLE
Add email attachment support with Nodemailer integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "@gongrzhe/server-gmail-autoauth-mcp",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gongrzhe/server-gmail-autoauth-mcp",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.4.0",
+        "@types/mime-types": "^2.1.4",
         "google-auth-library": "^9.4.1",
         "googleapis": "^129.0.0",
         "mcp-evals": "^1.0.18",
+        "mime-types": "^3.0.1",
+        "nodemailer": "^7.0.3",
         "open": "^10.0.0",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.22.1"
@@ -22,6 +25,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.10.5",
+        "@types/nodemailer": "^6.4.17",
         "typescript": "^5.3.3"
       },
       "engines": {
@@ -614,6 +618,12 @@
       "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
       "license": "MIT"
     },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.17.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
@@ -631,6 +641,16 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abort-controller": {
@@ -653,27 +673,6 @@
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -1327,27 +1326,6 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
-    "node_modules/express/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1391,6 +1369,27 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "license": "MIT"
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
@@ -1934,21 +1933,21 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -2025,6 +2024,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
+      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -2321,27 +2329,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/serve-static": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
@@ -2554,27 +2541,6 @@
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
       },
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -47,15 +47,19 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.4.0",
+    "@types/mime-types": "^2.1.4",
     "google-auth-library": "^9.4.1",
     "googleapis": "^129.0.0",
     "mcp-evals": "^1.0.18",
+    "mime-types": "^3.0.1",
+    "nodemailer": "^7.0.3",
     "open": "^10.0.0",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",
+    "@types/nodemailer": "^6.4.17",
     "typescript": "^5.3.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'url';
 import http from 'http';
 import open from 'open';
 import os from 'os';
-import {createEmailMessage, createEmailWithNodemailer, GmailMessagePart} from "./utl.js";
+import {createEmailMessage, createEmailWithNodemailer} from "./utl.js";
 import { createLabel, updateLabel, deleteLabel, listLabels, findLabelByName, getOrCreateLabel, GmailLabel } from "./label-manager.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -27,6 +27,21 @@ const OAUTH_PATH = process.env.GMAIL_OAUTH_PATH || path.join(CONFIG_DIR, 'gcp-oa
 const CREDENTIALS_PATH = process.env.GMAIL_CREDENTIALS_PATH || path.join(CONFIG_DIR, 'credentials.json');
 
 // Type definitions for Gmail API responses
+interface GmailMessagePart {
+    partId?: string;
+    mimeType?: string;
+    filename?: string;
+    headers?: Array<{
+        name: string;
+        value: string;
+    }>;
+    body?: {
+        attachmentId?: string;
+        size?: number;
+        data?: string;
+    };
+    parts?: GmailMessagePart[];
+}
 
 interface EmailAttachment {
     id: string;

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -115,8 +115,6 @@ export function createEmailMessage(validatedArgs: any): string {
 
 
 export async function createEmailWithNodemailer(validatedArgs: any): Promise<string> {
-    console.log(`[DEBUG] createEmailWithNodemailer: Starting with ${validatedArgs.attachments?.length || 0} attachments`);
-    
     // Validate email addresses
     (validatedArgs.to as string[]).forEach(email => {
         if (!validateEmail(email)) {
@@ -139,7 +137,6 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
         }
         
         const fileName = path.basename(filePath);
-        console.log(`[DEBUG] Adding attachment: ${fileName}`);
         
         attachments.push({
             filename: fileName,
@@ -164,7 +161,6 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
     const info = await transporter.sendMail(mailOptions);
     const rawMessage = info.message.toString();
     
-    console.log(`[DEBUG] Generated raw RFC822 message, length: ${rawMessage.length}`);
     return rawMessage;
 }
 

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -1,3 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { lookup as mimeLookup } from 'mime-types';
+import nodemailer from 'nodemailer';
+
+// Gmail API MessagePart interface (matching the API documentation)
+export interface GmailMessagePart {
+    partId?: string;
+    mimeType?: string;
+    filename?: string;
+    headers?: Array<{
+        name: string;
+        value: string;
+    }>;
+    body?: {
+        attachmentId?: string;
+        size?: number;
+        data?: string;
+    };
+    parts?: GmailMessagePart[];
+}
+
 /**
  * Helper function to encode email headers containing non-ASCII characters
  * according to RFC 2047 MIME specification
@@ -90,3 +112,59 @@ export function createEmailMessage(validatedArgs: any): string {
 
     return emailParts.join('\r\n');
 }
+
+
+export async function createEmailWithNodemailer(validatedArgs: any): Promise<string> {
+    console.log(`[DEBUG] createEmailWithNodemailer: Starting with ${validatedArgs.attachments?.length || 0} attachments`);
+    
+    // Validate email addresses
+    (validatedArgs.to as string[]).forEach(email => {
+        if (!validateEmail(email)) {
+            throw new Error(`Recipient email address is invalid: ${email}`);
+        }
+    });
+
+    // Create a nodemailer transporter (we won't actually send, just generate the message)
+    const transporter = nodemailer.createTransport({
+        streamTransport: true,
+        newline: 'unix',
+        buffer: true
+    });
+
+    // Prepare attachments for nodemailer
+    const attachments = [];
+    for (const filePath of validatedArgs.attachments) {
+        if (!fs.existsSync(filePath)) {
+            throw new Error(`File does not exist: ${filePath}`);
+        }
+        
+        const fileName = path.basename(filePath);
+        console.log(`[DEBUG] Adding attachment: ${fileName}`);
+        
+        attachments.push({
+            filename: fileName,
+            path: filePath
+        });
+    }
+
+    const mailOptions = {
+        from: 'me', // Gmail API will replace this with the authenticated user
+        to: validatedArgs.to.join(', '),
+        cc: validatedArgs.cc?.join(', '),
+        bcc: validatedArgs.bcc?.join(', '),
+        subject: validatedArgs.subject,
+        text: validatedArgs.body,
+        html: validatedArgs.htmlBody,
+        attachments: attachments,
+        inReplyTo: validatedArgs.inReplyTo,
+        references: validatedArgs.inReplyTo
+    };
+
+    // Generate the raw message
+    const info = await transporter.sendMail(mailOptions);
+    const rawMessage = info.message.toString();
+    
+    console.log(`[DEBUG] Generated raw RFC822 message, length: ${rawMessage.length}`);
+    return rawMessage;
+}
+

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -3,23 +3,6 @@ import path from 'path';
 import { lookup as mimeLookup } from 'mime-types';
 import nodemailer from 'nodemailer';
 
-// Gmail API MessagePart interface (matching the API documentation)
-export interface GmailMessagePart {
-    partId?: string;
-    mimeType?: string;
-    filename?: string;
-    headers?: Array<{
-        name: string;
-        value: string;
-    }>;
-    body?: {
-        attachmentId?: string;
-        size?: number;
-        data?: string;
-    };
-    parts?: GmailMessagePart[];
-}
-
 /**
  * Helper function to encode email headers containing non-ASCII characters
  * according to RFC 2047 MIME specification


### PR DESCRIPTION
## Summary
- Adds full attachment support to `send_email` and `draft_email` tools using battle-tested Nodemailer library
- Implements new `download_attachment` tool for retrieving email attachments from Gmail
- Replaces manual MIME message construction with proper RFC822 formatting via Nodemailer's streamTransport

## Key Features
- **Email attachments**: Send emails with file attachments via existing tools
- **Attachment downloads**: Download attachments from received emails to local filesystem  
- **Proper MIME formatting**: Uses Nodemailer to generate standards-compliant RFC822 messages
- **Enhanced attachment display**: Shows attachment IDs in email reading for easy download reference

## Technical Implementation
- Uses Nodemailer's `streamTransport` to generate RFC822 messages without sending
- Passes properly formatted raw messages to Gmail API for reliable delivery
- Adds MIME type detection and file validation for robust attachment handling
- Maintains backward compatibility - existing functionality unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)