### PR TITLE
fix: Add response size control options to read_email tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,13 +232,29 @@ Creates a draft email without sending it.
 ```
 
 ### 3. Read Email (`read_email`)
-Retrieves the content of a specific email by its ID.
+Retrieves the content of a specific email by its ID with options to control response size.
 
 ```json
 {
-  "messageId": "182ab45cd67ef"
+  "messageId": "182ab45cd67ef",
+  "includeAttachments": true,
+  "includeHtml": true,
+  "maxBodyLength": 10000,
+  "format": "full"
 }
 ```
+
+**Parameters:**
+- `messageId` (required): ID of the email message to retrieve
+- `includeAttachments` (optional): Whether to include attachment information (default: true)
+- `includeHtml` (optional): Whether to include HTML content (default: true)
+- `maxBodyLength` (optional): Maximum length of body content to return (truncates if exceeded)
+- `format` (optional): Response format options:
+  - `"full"` (default): Complete email with all content
+  - `"summary"`: Key information with 500-character body preview
+  - `"headers_only"`: Only email headers without body content
+
+This helps prevent token limit errors when reading large emails with attachments or extensive HTML content.
 
 ### 4. Search Emails (`search_emails`)
 Searches for emails using Gmail search syntax.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gongrzhe/server-gmail-autoauth-mcp",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gongrzhe/server-gmail-autoauth-mcp",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.4.0",


### PR DESCRIPTION
## Summary
- Adds optional parameters to control response size for the `read_email` tool
- Prevents token limit errors when reading large emails with attachments or extensive HTML content
- Fixes #33 

## Changes
1. **New optional parameters for `read_email`:**
   - `includeAttachments` (boolean): Control whether to include attachment information (default: true)
   - `includeHtml` (boolean): Control whether to include HTML content (default: true)
   - `maxBodyLength` (number): Maximum length of body content to return (truncates if exceeded)
   - `format` (string): Response format options:
     - `"full"` (default): Complete email with all content
     - `"summary"`: Key information with 500-character body preview  
     - `"headers_only"`: Only email headers without body content

2. **Updated README documentation** with detailed parameter descriptions and examples

## Test Plan
- [x] Compiled TypeScript code successfully
- [ ] Test with regular-sized emails to ensure backward compatibility
- [ ] Test with large emails to verify truncation works correctly
- [ ] Test different format options (full, summary, headers_only)
- [ ] Test with/without attachments and HTML content

## Example Usage
```json
{
  "messageId": "182ab45cd67ef",
  "includeAttachments": false,
  "maxBodyLength": 5000,
  "format": "summary"
}
```

This fix ensures that users can successfully read any email regardless of size, preventing the "exceeds maximum allowed tokens" error reported in the issue.

🤖 Generated with [Claude Code](https://claude.ai/code)