### PR TITLE
feat: add send-as alias support with custom display names

### DIFF
--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -1,4 +1,4 @@
-//evals.ts
+//evals.ts - Enhanced evaluations including alias functionality
 
 import { EvalConfig } from 'mcp-evals';
 import { openai } from "@ai-sdk/openai";
@@ -13,9 +13,27 @@ const send_emailEval: EvalFunction = {
     }
 };
 
+const send_email_with_aliasEval: EvalFunction = {
+    name: "send_email_with_aliasEval",
+    description: "Evaluates sending an email from a specific alias",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Send an email to client@example.com from my work alias work@mycompany.com with the subject 'Project Update' and a professional message about project status.");
+        return JSON.parse(result);
+    }
+};
+
+const list_aliasesEval: EvalFunction = {
+    name: "list_aliasesEval",
+    description: "Evaluates listing send-as aliases",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please show me all my available send-as email aliases including their verification status.");
+        return JSON.parse(result);
+    }
+};
+
 const draft_email: EvalFunction = {
     name: 'draft_email',
-    description: 'Evaluates the tool’s ability to draft an email',
+    description: 'Evaluates the tool\'s ability to draft an email',
     run: async () => {
         const result = await grade(openai("gpt-4"), "Draft a new email to my manager requesting a meeting to discuss project updates and timelines.");
         return JSON.parse(result);
@@ -49,11 +67,60 @@ const modify_emailEval: EvalFunction = {
     }
 };
 
+const download_attachmentEval: EvalFunction = {
+    name: 'download_attachment Tool Evaluation',
+    description: 'Evaluates downloading email attachments',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Download the PDF attachment from the email with subject 'Invoice #123' and save it to my Downloads folder.");
+        return JSON.parse(result);
+    }
+};
+
+const batch_operationsEval: EvalFunction = {
+    name: 'batch_operations Tool Evaluation',
+    description: 'Evaluates batch email operations',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Mark all emails from newsletter@example.com as read and move them to the 'Newsletter' label in a single batch operation.");
+        return JSON.parse(result);
+    }
+};
+
+const label_managementEval: EvalFunction = {
+    name: 'label_management Tool Evaluation',
+    description: 'Evaluates Gmail label management functionality',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Create a new Gmail label called 'Important Projects' and list all my current labels showing both system and user-defined labels.");
+        return JSON.parse(result);
+    }
+};
+
 const config: EvalConfig = {
     model: openai("gpt-4"),
-    evals: [send_emailEval, draft_email, read_emailEval, search_emailsEval, modify_emailEval]
+    evals: [
+        send_emailEval, 
+        send_email_with_aliasEval,
+        list_aliasesEval,
+        draft_email, 
+        read_emailEval, 
+        search_emailsEval, 
+        modify_emailEval,
+        download_attachmentEval,
+        batch_operationsEval,
+        label_managementEval
+    ]
 };
   
 export default config;
   
-export const evals = [send_emailEval, draft_email, read_emailEval, search_emailsEval, modify_emailEval];
+export const evals = [
+    send_emailEval, 
+    send_email_with_aliasEval,
+    list_aliasesEval,
+    draft_email, 
+    read_emailEval, 
+    search_emailsEval, 
+    modify_emailEval,
+    download_attachmentEval,
+    batch_operationsEval,
+    label_managementEval
+];

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -42,9 +42,20 @@ export function createEmailMessage(validatedArgs: any): string {
         }
     });
 
+    // Format the From header with optional display name
+    const formatFromAddress = () => {
+        const email = validatedArgs.from || 'me';
+        if (validatedArgs.fromName) {
+            // Encode display name if it contains non-ASCII characters
+            const encodedName = encodeEmailHeader(validatedArgs.fromName);
+            return `${encodedName} <${email}>`;
+        }
+        return email;
+    };
+
     // Common email headers
     const emailParts = [
-        'From: me',
+        `From: ${formatFromAddress()}`,
         `To: ${validatedArgs.to.join(', ')}`,
         validatedArgs.cc ? `Cc: ${validatedArgs.cc.join(', ')}` : '',
         validatedArgs.bcc ? `Bcc: ${validatedArgs.bcc.join(', ')}` : '',
@@ -127,8 +138,17 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
         });
     }
 
+    // Format the From field with optional display name for Nodemailer
+    const formatFromForNodemailer = () => {
+        const email = validatedArgs.from || 'me';
+        if (validatedArgs.fromName) {
+            return `${validatedArgs.fromName} <${email}>`;
+        }
+        return email;
+    };
+
     const mailOptions = {
-        from: 'me', // Gmail API will replace this with the authenticated user
+        from: formatFromForNodemailer(), // Use specified from address with optional display name
         to: validatedArgs.to.join(', '),
         cc: validatedArgs.cc?.join(', '),
         bcc: validatedArgs.bcc?.join(', '),


### PR DESCRIPTION
- Add optional 'from' parameter to send/draft emails from verified aliases
- Add optional 'fromName' parameter for custom display names
- Add list_send_as_aliases tool to view available aliases
- Support RFC 2047 encoding for international characters in display names
- Maintain backward compatibility with existing email sending
- Add new OAuth scope: gmail.settings.basic for alias access
- Enhanced evaluations to include alias functionality testing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>