### PR TITLE
fix: email threading with RFC 5322 compliance and automatic References chain

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,9 +199,9 @@ const SendEmailSchema = z.object({
     mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
     cc: z.array(z.string()).optional().describe("List of CC recipients"),
     bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
-    threadId: z.string().optional().describe("Thread ID to reply to"),
+    threadId: z.string().optional().describe("Thread ID to reply to. When replying (inReplyTo set), threadId enables automatic References chain building"),
     inReplyTo: z.string().optional().describe("Message ID being replied to"),
-    references: z.string().optional().describe("Full References header chain for proper email threading"),
+    references: z.string().optional().describe("Full References header chain (auto-built from threadId if not provided). Format: '<msg1@example.com> <msg2@example.com>'"),
     attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
 });
 
@@ -602,6 +602,31 @@ async function main() {
                 case "send_email":
                 case "draft_email": {
                     const validatedArgs = SendEmailSchema.parse(args);
+                    
+                    if (validatedArgs.inReplyTo && !validatedArgs.references && validatedArgs.threadId) {
+                        try {
+                            const thread = await gmail.users.threads.get({
+                                userId: 'me',
+                                id: validatedArgs.threadId,
+                                format: 'full'
+                            });
+                            
+                            const messageIds = thread.data.messages
+                                ?.map(msg => {
+                                    const headers = msg.payload?.headers || [];
+                                    return headers.find(h => h.name?.toLowerCase() === 'message-id')?.value;
+                                })
+                                .filter(Boolean)
+                                .map(id => id && (id.includes('<') ? id : `<${id}>`));
+                            
+                            if (messageIds && messageIds.length > 0) {
+                                validatedArgs.references = messageIds.join(' ');
+                            }
+                        } catch (error) {
+                            console.warn('Could not auto-build references chain:', error);
+                        }
+                    }
+                    
                     const action = name === "send_email" ? "send" : "draft";
                     return await handleEmailAction(action, validatedArgs);
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,7 @@ const SendEmailSchema = z.object({
     bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
     threadId: z.string().optional().describe("Thread ID to reply to"),
     inReplyTo: z.string().optional().describe("Message ID being replied to"),
+    references: z.string().optional().describe("Full References header chain for proper email threading"),
     attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
 });
 
@@ -618,6 +619,8 @@ async function main() {
                     const from = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
                     const to = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
                     const date = headers.find(h => h.name?.toLowerCase() === 'date')?.value || '';
+                    const messageId = headers.find(h => h.name?.toLowerCase() === 'message-id')?.value || '';
+                    const references = headers.find(h => h.name?.toLowerCase() === 'references')?.value || '';
                     const threadId = response.data.threadId || '';
 
                     // Extract email content using the recursive function
@@ -664,7 +667,7 @@ async function main() {
                         content: [
                             {
                                 type: "text",
-                                text: `Thread ID: ${threadId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
+                                text: `Thread ID: ${threadId}\nMessage-ID: ${messageId}\nReferences: ${references}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
                             },
                         ],
                     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,9 +199,9 @@ const SendEmailSchema = z.object({
     mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
     cc: z.array(z.string()).optional().describe("List of CC recipients"),
     bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
-    threadId: z.string().optional().describe("Thread ID to reply to. When replying (inReplyTo set), threadId enables automatic References chain building"),
-    inReplyTo: z.string().optional().describe("Message ID being replied to"),
-    references: z.string().optional().describe("Full References header chain (auto-built from threadId if not provided). Format: '<msg1@example.com> <msg2@example.com>'"),
+    threadId: z.string().optional().describe("Thread ID to reply to. REQUIRED when using inReplyTo for automatic References chain building (proper email threading)"),
+    inReplyTo: z.string().optional().describe("Message ID being replied to. Must be used with threadId for proper threading"),
+    references: z.string().optional().describe("Full References header chain (auto-built from threadId when replying). Manual override only if needed. Format: '<msg1@example.com> <msg2@example.com>'"),
     attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
 });
 

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -49,9 +49,8 @@ export function createEmailMessage(validatedArgs: any): string {
         validatedArgs.cc ? `Cc: ${validatedArgs.cc.join(', ')}` : '',
         validatedArgs.bcc ? `Bcc: ${validatedArgs.bcc.join(', ')}` : '',
         `Subject: ${encodedSubject}`,
-        // Add thread-related headers if specified
         validatedArgs.inReplyTo ? `In-Reply-To: ${validatedArgs.inReplyTo}` : '',
-        validatedArgs.inReplyTo ? `References: ${validatedArgs.inReplyTo}` : '',
+        validatedArgs.references ? `References: ${validatedArgs.references}` : (validatedArgs.inReplyTo ? `References: ${validatedArgs.inReplyTo}` : ''),
         'MIME-Version: 1.0',
     ].filter(Boolean);
 
@@ -128,7 +127,7 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
     }
 
     const mailOptions = {
-        from: 'me', // Gmail API will replace this with the authenticated user
+        from: 'me',
         to: validatedArgs.to.join(', '),
         cc: validatedArgs.cc?.join(', '),
         bcc: validatedArgs.bcc?.join(', '),
@@ -137,7 +136,7 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
         html: validatedArgs.htmlBody,
         attachments: attachments,
         inReplyTo: validatedArgs.inReplyTo,
-        references: validatedArgs.inReplyTo
+        references: validatedArgs.references || validatedArgs.inReplyTo
     };
 
     // Generate the raw message

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -49,8 +49,8 @@ export function createEmailMessage(validatedArgs: any): string {
         validatedArgs.cc ? `Cc: ${validatedArgs.cc.join(', ')}` : '',
         validatedArgs.bcc ? `Bcc: ${validatedArgs.bcc.join(', ')}` : '',
         `Subject: ${encodedSubject}`,
-        validatedArgs.inReplyTo ? `In-Reply-To: ${validatedArgs.inReplyTo}` : '',
-        validatedArgs.references ? `References: ${validatedArgs.references}` : (validatedArgs.inReplyTo ? `References: ${validatedArgs.inReplyTo}` : ''),
+        validatedArgs.inReplyTo ? `In-Reply-To: <${validatedArgs.inReplyTo}>` : '',
+        validatedArgs.references ? `References: ${validatedArgs.references}` : (validatedArgs.inReplyTo ? `References: <${validatedArgs.inReplyTo}>` : ''),
         'MIME-Version: 1.0',
     ].filter(Boolean);
 


### PR DESCRIPTION
## Problem
Email replies sent via `send_email` tool weren't threading properly in Gmail's UI. Emails appeared as separate messages instead of being grouped in a conversation thread.

## Root Cause
After systematic testing and header analysis:

1. **Missing angle brackets**: Message-IDs in `In-Reply-To` and `References` headers lacked RFC 5322 required angle brackets
2. **Incomplete References chain**: Only immediate parent Message-ID included, not full conversation chain
3. **Manual chain building**: Required users to manually build References chain (unlike Gmail/Thunderbird auto-behavior)

## Solution

### 1. RFC 5322 Compliance
- Add angle brackets `<>` around Message-IDs in threading headers
- Support explicit `references` parameter for custom chains
- Update both simple and nodemailer email creation

### 2. Automatic References Chain Building
When replying (`inReplyTo` set) without explicit `references`:
- Automatically fetches complete thread via `threadId`
- Extracts all Message-IDs in chronological order
- Builds proper References chain matching Gmail behavior
- Graceful fallback if `threadId` missing or API fails

## Changes

**src/index.ts:**
- Added `references` parameter to `SendEmailSchema`
- Extract `Message-ID` and `References` headers in `read_email`
- Auto-build References chain from threadId when replying
- Include threading headers in output for debugging

**src/utl.ts:**
- Add angle brackets around Message-IDs
- Support explicit `references` chain or fallback to `inReplyTo`
- Update nodemailer configuration

## Technical Details

### Before (broken):
```
In-Reply-To: abc123@example.com
References: abc123@example.com
```

### After (working):
```
In-Reply-To: <abc123@example.com>
References: <msg1@example.com> <msg2@example.com> <abc123@example.com>
```

### Usage

**Simple (automatic):**
```javascript
// References chain built automatically from threadId
{
  inReplyTo: "abc123@example.com",
  threadId: "thread123",
  // references auto-built!
}
```

**Advanced (manual override):**
```javascript
{
  inReplyTo: "xyz789@example.com",
  references: "<msg1@example.com> <msg2@example.com> <xyz789@example.com>"
  // explicit chain used
}
```

## Testing
- [x] Code builds successfully
- [x] Manual testing: emails thread correctly in Gmail UI
- [x] Manual testing: emails thread correctly in Thunderbird
- [x] Automatic chain building verified working
- [x] No breaking changes to existing functionality

## Impact
- **Fixes**: Email threading for Gmail API users
- **Backwards Compatible**: Yes (new features are optional)
- **Breaking Changes**: None
- **Behavior**: Matches Gmail/Thunderbird automatic threading

## References
- [RFC 5322: Internet Message Format](https://www.rfc-editor.org/rfc/rfc5322#section-3.6.4)
- [Gmail API Threading Documentation](https://developers.google.com/gmail/api/guides/threads)