### PR TITLE
fix: listFilters response key

### DIFF
--- a/src/filter-manager.ts
+++ b/src/filter-manager.ts
@@ -67,7 +67,7 @@ export async function listFilters(gmail: any) {
             userId: 'me',
         });
 
-        const filters = response.data.filters || [];
+        const filters = response.data.filter || [];
         
         return {
             filters,


### PR DESCRIPTION
Gmail API returns `response.data.filter` (singular), not `response.data.filters`