### PR TITLE
Fix email threading by properly formatting In-Reply-To and References headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "start": "node dist/index.js",
     "auth": "node dist/index.js auth",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "files": [
     "dist",
@@ -60,6 +62,7 @@
   "devDependencies": {
     "@types/node": "^20.10.5",
     "@types/nodemailer": "^6.4.17",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^2.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,8 @@ const SendEmailSchema = z.object({
     cc: z.array(z.string()).optional().describe("List of CC recipients"),
     bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
     threadId: z.string().optional().describe("Thread ID to reply to"),
-    inReplyTo: z.string().optional().describe("Message ID being replied to"),
+    inReplyTo: z.string().optional().describe("Message ID being replied to (angle brackets optional)"),
+    references: z.union([z.string(), z.array(z.string())]).optional().describe("Message ID(s) for the References header. For long threads, provide an array of all message IDs in the chain. If not provided, defaults to inReplyTo value."),
     attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
 });
 

--- a/src/utl.test.ts
+++ b/src/utl.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { formatMessageId, formatReferences } from './utl.js';
+
+describe('formatMessageId', () => {
+  it('adds angle brackets if missing', () => {
+    expect(formatMessageId('abc123@mail.com')).toBe('<abc123@mail.com>');
+  });
+
+  it('preserves existing angle brackets', () => {
+    expect(formatMessageId('<abc123@mail.com>')).toBe('<abc123@mail.com>');
+  });
+
+  it('handles empty input', () => {
+    expect(formatMessageId('')).toBe('<>');
+  });
+
+  it('trims whitespace before processing', () => {
+    expect(formatMessageId('  abc123@mail.com  ')).toBe('<abc123@mail.com>');
+  });
+
+  it('trims whitespace and preserves existing brackets', () => {
+    expect(formatMessageId('  <abc123@mail.com>  ')).toBe('<abc123@mail.com>');
+  });
+
+  it('handles message IDs with special characters', () => {
+    expect(formatMessageId('CABx=+abc_123.test@mail.gmail.com')).toBe('<CABx=+abc_123.test@mail.gmail.com>');
+  });
+
+  it('handles Gmail-style message IDs', () => {
+    const gmailId = 'CABx+4AQxdT_p8M0F=O3J+xyz@mail.gmail.com';
+    expect(formatMessageId(gmailId)).toBe(`<${gmailId}>`);
+  });
+});
+
+describe('formatReferences', () => {
+  it('formats single message ID without brackets', () => {
+    expect(formatReferences('abc@mail.com')).toBe('<abc@mail.com>');
+  });
+
+  it('formats single message ID with existing brackets', () => {
+    expect(formatReferences('<abc@mail.com>')).toBe('<abc@mail.com>');
+  });
+
+  it('formats array of message IDs', () => {
+    expect(formatReferences(['a@mail.com', 'b@mail.com'])).toBe('<a@mail.com> <b@mail.com>');
+  });
+
+  it('formats array with existing brackets', () => {
+    expect(formatReferences(['<a@mail.com>', '<b@mail.com>'])).toBe('<a@mail.com> <b@mail.com>');
+  });
+
+  it('handles mixed array (some with brackets, some without)', () => {
+    expect(formatReferences(['a@mail.com', '<b@mail.com>', 'c@mail.com'])).toBe('<a@mail.com> <b@mail.com> <c@mail.com>');
+  });
+
+  it('handles single-element array', () => {
+    expect(formatReferences(['only@mail.com'])).toBe('<only@mail.com>');
+  });
+
+  it('handles empty array', () => {
+    expect(formatReferences([])).toBe('');
+  });
+
+  it('handles long thread chains', () => {
+    const chain = [
+      'msg1@mail.com',
+      'msg2@mail.com',
+      'msg3@mail.com',
+      'msg4@mail.com',
+      'msg5@mail.com'
+    ];
+    expect(formatReferences(chain)).toBe('<msg1@mail.com> <msg2@mail.com> <msg3@mail.com> <msg4@mail.com> <msg5@mail.com>');
+  });
+});

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -21,7 +21,7 @@ function encodeEmailHeader(text: string): string {
  * Gmail API returns Message-IDs that may or may not include angle brackets,
  * but the In-Reply-To and References headers require them.
  */
-function formatMessageId(messageId: string): string {
+export function formatMessageId(messageId: string): string {
     const trimmed = messageId.trim();
     if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
         return trimmed;
@@ -34,7 +34,7 @@ function formatMessageId(messageId: string): string {
  * an array of message IDs (for long thread chains).
  * Per RFC 2822, References should contain the full chain of message IDs.
  */
-function formatReferences(references: string | string[]): string {
+export function formatReferences(references: string | string[]): string {
     if (Array.isArray(references)) {
         return references.map(formatMessageId).join(' ');
     }

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -16,6 +16,31 @@ function encodeEmailHeader(text: string): string {
     return text;
 }
 
+/**
+ * Ensures a Message-ID is properly formatted with angle brackets per RFC 2822.
+ * Gmail API returns Message-IDs that may or may not include angle brackets,
+ * but the In-Reply-To and References headers require them.
+ */
+function formatMessageId(messageId: string): string {
+    const trimmed = messageId.trim();
+    if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+        return trimmed;
+    }
+    return `<${trimmed}>`;
+}
+
+/**
+ * Formats the References header value. Can accept a single message ID or
+ * an array of message IDs (for long thread chains).
+ * Per RFC 2822, References should contain the full chain of message IDs.
+ */
+function formatReferences(references: string | string[]): string {
+    if (Array.isArray(references)) {
+        return references.map(formatMessageId).join(' ');
+    }
+    return formatMessageId(references);
+}
+
 export const validateEmail = (email: string): boolean => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
@@ -49,9 +74,10 @@ export function createEmailMessage(validatedArgs: any): string {
         validatedArgs.cc ? `Cc: ${validatedArgs.cc.join(', ')}` : '',
         validatedArgs.bcc ? `Bcc: ${validatedArgs.bcc.join(', ')}` : '',
         `Subject: ${encodedSubject}`,
-        // Add thread-related headers if specified
-        validatedArgs.inReplyTo ? `In-Reply-To: ${validatedArgs.inReplyTo}` : '',
-        validatedArgs.inReplyTo ? `References: ${validatedArgs.inReplyTo}` : '',
+        // Add thread-related headers if specified (RFC 2822 requires angle brackets)
+        validatedArgs.inReplyTo ? `In-Reply-To: ${formatMessageId(validatedArgs.inReplyTo)}` : '',
+        validatedArgs.references ? `References: ${formatReferences(validatedArgs.references)}` :
+            (validatedArgs.inReplyTo ? `References: ${formatMessageId(validatedArgs.inReplyTo)}` : ''),
         'MIME-Version: 1.0',
     ].filter(Boolean);
 
@@ -127,6 +153,12 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
         });
     }
 
+    // Format thread-related headers with proper angle brackets (RFC 2822)
+    const inReplyTo = validatedArgs.inReplyTo ? formatMessageId(validatedArgs.inReplyTo) : undefined;
+    const references = validatedArgs.references
+        ? formatReferences(validatedArgs.references)
+        : (validatedArgs.inReplyTo ? formatMessageId(validatedArgs.inReplyTo) : undefined);
+
     const mailOptions = {
         from: 'me', // Gmail API will replace this with the authenticated user
         to: validatedArgs.to.join(', '),
@@ -136,8 +168,8 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
         text: validatedArgs.body,
         html: validatedArgs.htmlBody,
         attachments: attachments,
-        inReplyTo: validatedArgs.inReplyTo,
-        references: validatedArgs.inReplyTo
+        inReplyTo: inReplyTo,
+        references: references
     };
 
     // Generate the raw message

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

This PR fixes Issue #66 where email replies were not staying in the thread due to improperly formatted `In-Reply-To` and `References` headers.

**Root Cause**: RFC 2822 requires Message-IDs in email headers to be wrapped in angle brackets (e.g., `<message-id@example.com>`). The Gmail API returns Message-IDs that may or may not include these brackets, but the code was passing them through as-is, causing threading to fail.

**Changes**:
- Added `formatMessageId()` helper to ensure Message-IDs always have angle brackets
- Added `formatReferences()` helper to handle both single IDs and arrays (for long thread chains)
- Updated `createEmailMessage()` to use proper header formatting
- Updated `createEmailWithNodemailer()` to use proper header formatting  
- Added new optional `references` parameter to the schema to support providing the full message chain for long threads

## Test plan

- [ ] Reply to an email using `send_email` with `threadId` and `inReplyTo` - verify the reply appears in the same thread
- [ ] Reply to an email using `draft_email` with `threadId` and `inReplyTo` - verify the draft shows as part of the thread
- [ ] Test with a Message-ID that already has angle brackets - verify it's not double-wrapped
- [ ] Test with a Message-ID without angle brackets - verify brackets are added
- [ ] Test with attachments (uses nodemailer path) - verify threading still works

Fixes #66

---
Generated with [Claude Code](https://claude.ai/claude-code)