### PR TITLE
Add reply_all tool for replying to all recipients

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "auth": "node dist/index.js auth",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
@@ -60,6 +62,7 @@
   "devDependencies": {
     "@types/node": "^20.10.5",
     "@types/nodemailer": "^6.4.17",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import os from 'os';
 import {createEmailMessage, createEmailWithNodemailer} from "./utl.js";
 import { createLabel, updateLabel, deleteLabel, listLabels, findLabelByName, getOrCreateLabel, GmailLabel } from "./label-manager.js";
 import { createFilter, listFilters, getFilter, deleteFilter, filterTemplates, GmailFilterCriteria, GmailFilterAction } from "./filter-manager.js";
+import { parseEmailAddresses, filterOutEmail, addRePrefix, buildReferencesHeader, buildReplyAllRecipients } from "./reply-all-helpers.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1223,58 +1224,23 @@ async function main() {
                     const profile = await gmail.users.getProfile({ userId: 'me' });
                     const myEmail = profile.data.emailAddress?.toLowerCase() || '';
 
-                    // Helper function to parse email addresses from header value
-                    const parseEmails = (headerValue: string): string[] => {
-                        if (!headerValue) return [];
-                        // Split by comma, but handle cases like "Name <email@example.com>"
-                        const emails: string[] = [];
-                        const parts = headerValue.split(',');
-                        for (const part of parts) {
-                            const trimmed = part.trim();
-                            // Extract email from "Name <email>" format
-                            const match = trimmed.match(/<([^>]+)>/);
-                            if (match) {
-                                emails.push(match[1].trim());
-                            } else if (trimmed.includes('@')) {
-                                emails.push(trimmed);
-                            }
-                        }
-                        return emails;
-                    };
-
-                    // Helper function to filter out authenticated user's email
-                    const filterMyEmail = (emails: string[]): string[] => {
-                        return emails.filter(email => email.toLowerCase() !== myEmail);
-                    };
-
-                    // Build recipient list:
-                    // - TO: original sender (From)
-                    // - CC: original To and CC (excluding myself)
-                    const fromEmails = parseEmails(originalFrom);
-                    const toEmails = parseEmails(originalTo);
-                    const ccEmails = parseEmails(originalCc);
-
-                    // TO recipients: original From (the person who sent the email)
-                    const replyTo = filterMyEmail(fromEmails);
-
-                    // CC recipients: everyone else who was on To and CC, excluding myself
-                    const replyCc = filterMyEmail([...toEmails, ...ccEmails]);
+                    // Build recipient list using helper functions
+                    const { to: replyTo, cc: replyCc } = buildReplyAllRecipients(
+                        originalFrom,
+                        originalTo,
+                        originalCc,
+                        myEmail
+                    );
 
                     if (replyTo.length === 0) {
                         throw new Error('Could not determine recipient for reply');
                     }
 
                     // Build subject with "Re:" prefix if not already present
-                    let replySubject = originalSubject;
-                    if (!replySubject.toLowerCase().startsWith('re:')) {
-                        replySubject = `Re: ${replySubject}`;
-                    }
+                    const replySubject = addRePrefix(originalSubject);
 
                     // Build References header (original References + original Message-ID)
-                    let references = originalReferences;
-                    if (originalMessageId) {
-                        references = references ? `${references} ${originalMessageId}` : originalMessageId;
-                    }
+                    const references = buildReferencesHeader(originalReferences, originalMessageId);
 
                     // Prepare the email arguments for handleEmailAction
                     const emailArgs = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -317,6 +317,15 @@ const DownloadAttachmentSchema = z.object({
     savePath: z.string().optional().describe("Directory path to save the attachment (defaults to current directory)"),
 });
 
+// Reply All schema - fetches original email and builds recipient list automatically
+const ReplyAllSchema = z.object({
+    messageId: z.string().describe("ID of the email message to reply to"),
+    body: z.string().describe("Reply body content (used for text/plain or when htmlBody not provided)"),
+    htmlBody: z.string().optional().describe("HTML version of the reply body"),
+    mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
+    attachments: z.array(z.string()).optional().describe("List of file paths to attach to the reply"),
+});
+
 
 // Main function
 async function main() {
@@ -437,6 +446,11 @@ async function main() {
                 name: "download_attachment",
                 description: "Downloads an email attachment to a specified location",
                 inputSchema: zodToJsonSchema(DownloadAttachmentSchema),
+            },
+            {
+                name: "reply_all",
+                description: "Replies to all recipients of an email. Automatically fetches the original email to build the recipient list (To, CC) and sets proper threading headers.",
+                inputSchema: zodToJsonSchema(ReplyAllSchema),
             },
         ],
     }))
@@ -1109,7 +1123,7 @@ async function main() {
                 }
                 case "download_attachment": {
                     const validatedArgs = DownloadAttachmentSchema.parse(args);
-                    
+
                     try {
                         // Get the attachment data from Gmail API
                         const attachmentResponse = await gmail.users.messages.attachments.get({
@@ -1129,7 +1143,7 @@ async function main() {
                         // Determine save path and filename
                         const savePath = validatedArgs.savePath || process.cwd();
                         let filename = validatedArgs.filename;
-                        
+
                         if (!filename) {
                             // Get original filename from message if not provided
                             const messageResponse = await gmail.users.messages.get({
@@ -1137,7 +1151,7 @@ async function main() {
                                 id: validatedArgs.messageId,
                                 format: 'full',
                             });
-                            
+
                             // Find the attachment part to get original filename
                             const findAttachment = (part: any): string | null => {
                                 if (part.body && part.body.attachmentId === validatedArgs.attachmentId) {
@@ -1151,7 +1165,7 @@ async function main() {
                                 }
                                 return null;
                             };
-                            
+
                             filename = findAttachment(messageResponse.data.payload) || `attachment-${validatedArgs.attachmentId}`;
                         }
 
@@ -1182,6 +1196,111 @@ async function main() {
                             ],
                         };
                     }
+                }
+
+                case "reply_all": {
+                    const validatedArgs = ReplyAllSchema.parse(args);
+
+                    // Fetch the original email to get headers
+                    const originalEmail = await gmail.users.messages.get({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        format: 'full',
+                    });
+
+                    const headers = originalEmail.data.payload?.headers || [];
+                    const threadId = originalEmail.data.threadId || '';
+
+                    // Extract relevant headers
+                    const originalFrom = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
+                    const originalTo = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
+                    const originalCc = headers.find(h => h.name?.toLowerCase() === 'cc')?.value || '';
+                    const originalSubject = headers.find(h => h.name?.toLowerCase() === 'subject')?.value || '';
+                    const originalMessageId = headers.find(h => h.name?.toLowerCase() === 'message-id')?.value || '';
+                    const originalReferences = headers.find(h => h.name?.toLowerCase() === 'references')?.value || '';
+
+                    // Get authenticated user's email to exclude from recipients
+                    const profile = await gmail.users.getProfile({ userId: 'me' });
+                    const myEmail = profile.data.emailAddress?.toLowerCase() || '';
+
+                    // Helper function to parse email addresses from header value
+                    const parseEmails = (headerValue: string): string[] => {
+                        if (!headerValue) return [];
+                        // Split by comma, but handle cases like "Name <email@example.com>"
+                        const emails: string[] = [];
+                        const parts = headerValue.split(',');
+                        for (const part of parts) {
+                            const trimmed = part.trim();
+                            // Extract email from "Name <email>" format
+                            const match = trimmed.match(/<([^>]+)>/);
+                            if (match) {
+                                emails.push(match[1].trim());
+                            } else if (trimmed.includes('@')) {
+                                emails.push(trimmed);
+                            }
+                        }
+                        return emails;
+                    };
+
+                    // Helper function to filter out authenticated user's email
+                    const filterMyEmail = (emails: string[]): string[] => {
+                        return emails.filter(email => email.toLowerCase() !== myEmail);
+                    };
+
+                    // Build recipient list:
+                    // - TO: original sender (From)
+                    // - CC: original To and CC (excluding myself)
+                    const fromEmails = parseEmails(originalFrom);
+                    const toEmails = parseEmails(originalTo);
+                    const ccEmails = parseEmails(originalCc);
+
+                    // TO recipients: original From (the person who sent the email)
+                    const replyTo = filterMyEmail(fromEmails);
+
+                    // CC recipients: everyone else who was on To and CC, excluding myself
+                    const replyCc = filterMyEmail([...toEmails, ...ccEmails]);
+
+                    if (replyTo.length === 0) {
+                        throw new Error('Could not determine recipient for reply');
+                    }
+
+                    // Build subject with "Re:" prefix if not already present
+                    let replySubject = originalSubject;
+                    if (!replySubject.toLowerCase().startsWith('re:')) {
+                        replySubject = `Re: ${replySubject}`;
+                    }
+
+                    // Build References header (original References + original Message-ID)
+                    let references = originalReferences;
+                    if (originalMessageId) {
+                        references = references ? `${references} ${originalMessageId}` : originalMessageId;
+                    }
+
+                    // Prepare the email arguments for handleEmailAction
+                    const emailArgs = {
+                        to: replyTo,
+                        cc: replyCc.length > 0 ? replyCc : undefined,
+                        subject: replySubject,
+                        body: validatedArgs.body,
+                        htmlBody: validatedArgs.htmlBody,
+                        mimeType: validatedArgs.mimeType,
+                        threadId: threadId,
+                        inReplyTo: originalMessageId,
+                        attachments: validatedArgs.attachments,
+                    };
+
+                    // Use the existing handleEmailAction to send the reply
+                    const result = await handleEmailAction("send", emailArgs);
+
+                    // Enhance the response with reply-all specific info
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Reply-all sent successfully!\nTo: ${replyTo.join(', ')}${replyCc.length > 0 ? `\nCC: ${replyCc.join(', ')}` : ''}\nSubject: ${replySubject}\nThread ID: ${threadId}`,
+                            },
+                        ],
+                    };
                 }
 
                 default:

--- a/src/reply-all-helpers.test.ts
+++ b/src/reply-all-helpers.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import {
+    parseEmailAddresses,
+    filterOutEmail,
+    addRePrefix,
+    buildReferencesHeader,
+    buildReplyAllRecipients
+} from './reply-all-helpers.js';
+
+describe('parseEmailAddresses', () => {
+    it('extracts email from simple email address', () => {
+        expect(parseEmailAddresses('user@example.com')).toEqual(['user@example.com']);
+    });
+
+    it('extracts email from "Name <email>" format', () => {
+        expect(parseEmailAddresses('John Doe <john@example.com>')).toEqual(['john@example.com']);
+    });
+
+    it('handles multiple addresses separated by commas', () => {
+        expect(parseEmailAddresses('alice@example.com, bob@example.com'))
+            .toEqual(['alice@example.com', 'bob@example.com']);
+    });
+
+    it('handles mixed formats with multiple addresses', () => {
+        expect(parseEmailAddresses('Alice <alice@example.com>, bob@example.com, Carol Smith <carol@example.com>'))
+            .toEqual(['alice@example.com', 'bob@example.com', 'carol@example.com']);
+    });
+
+    it('handles empty string', () => {
+        expect(parseEmailAddresses('')).toEqual([]);
+    });
+
+    it('handles whitespace around addresses', () => {
+        expect(parseEmailAddresses('  user@example.com  ,  other@example.com  '))
+            .toEqual(['user@example.com', 'other@example.com']);
+    });
+
+    it('handles angle brackets with spaces', () => {
+        expect(parseEmailAddresses('Name < email@example.com >')).toEqual(['email@example.com']);
+    });
+
+    it('ignores entries without @ symbol', () => {
+        expect(parseEmailAddresses('invalid, user@example.com')).toEqual(['user@example.com']);
+    });
+});
+
+describe('filterOutEmail', () => {
+    it('filters out matching email', () => {
+        const emails = ['alice@example.com', 'bob@example.com', 'carol@example.com'];
+        expect(filterOutEmail(emails, 'bob@example.com')).toEqual(['alice@example.com', 'carol@example.com']);
+    });
+
+    it('is case insensitive', () => {
+        const emails = ['Alice@Example.com', 'bob@example.com'];
+        expect(filterOutEmail(emails, 'alice@example.com')).toEqual(['bob@example.com']);
+    });
+
+    it('returns all emails if none match', () => {
+        const emails = ['alice@example.com', 'bob@example.com'];
+        expect(filterOutEmail(emails, 'carol@example.com')).toEqual(['alice@example.com', 'bob@example.com']);
+    });
+
+    it('handles empty array', () => {
+        expect(filterOutEmail([], 'user@example.com')).toEqual([]);
+    });
+
+    it('handles empty filter email', () => {
+        const emails = ['alice@example.com'];
+        expect(filterOutEmail(emails, '')).toEqual(['alice@example.com']);
+    });
+});
+
+describe('addRePrefix', () => {
+    it('adds Re: prefix to subject without it', () => {
+        expect(addRePrefix('Hello')).toBe('Re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (lowercase)', () => {
+        expect(addRePrefix('re: Hello')).toBe('re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (uppercase)', () => {
+        expect(addRePrefix('Re: Hello')).toBe('Re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (mixed case)', () => {
+        expect(addRePrefix('RE: Hello')).toBe('RE: Hello');
+    });
+
+    it('handles empty subject', () => {
+        expect(addRePrefix('')).toBe('Re: ');
+    });
+
+    it('adds prefix when subject starts with similar but not Re:', () => {
+        expect(addRePrefix('Regarding: Hello')).toBe('Re: Regarding: Hello');
+    });
+});
+
+describe('buildReferencesHeader', () => {
+    it('returns message ID when no original references', () => {
+        expect(buildReferencesHeader('', '<msg123@example.com>')).toBe('<msg123@example.com>');
+    });
+
+    it('appends message ID to existing references', () => {
+        expect(buildReferencesHeader('<ref1@example.com>', '<msg123@example.com>'))
+            .toBe('<ref1@example.com> <msg123@example.com>');
+    });
+
+    it('returns empty string when both are empty', () => {
+        expect(buildReferencesHeader('', '')).toBe('');
+    });
+
+    it('returns original references when message ID is empty', () => {
+        expect(buildReferencesHeader('<ref1@example.com>', '')).toBe('<ref1@example.com>');
+    });
+
+    it('handles multiple existing references', () => {
+        expect(buildReferencesHeader('<ref1@example.com> <ref2@example.com>', '<msg123@example.com>'))
+            .toBe('<ref1@example.com> <ref2@example.com> <msg123@example.com>');
+    });
+});
+
+describe('buildReplyAllRecipients', () => {
+    const myEmail = 'me@example.com';
+
+    it('puts original sender in To field', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'me@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual(['sender@example.com']);
+    });
+
+    it('puts original To and CC in CC field', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'recipient1@example.com, recipient2@example.com',
+            'cc1@example.com',
+            myEmail
+        );
+        expect(result.cc).toEqual(['recipient1@example.com', 'recipient2@example.com', 'cc1@example.com']);
+    });
+
+    it('excludes authenticated user from CC', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'me@example.com, other@example.com',
+            'me@example.com, another@example.com',
+            myEmail
+        );
+        expect(result.cc).toEqual(['other@example.com', 'another@example.com']);
+        expect(result.cc).not.toContain('me@example.com');
+    });
+
+    it('excludes authenticated user from To when sender is self', () => {
+        const result = buildReplyAllRecipients(
+            'me@example.com',
+            'recipient@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual([]);
+    });
+
+    it('handles Name <email> format in From', () => {
+        const result = buildReplyAllRecipients(
+            'John Doe <john@example.com>',
+            'me@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual(['john@example.com']);
+    });
+
+    it('handles complex scenario with mixed formats', () => {
+        const result = buildReplyAllRecipients(
+            'Alice <alice@example.com>',
+            'Me <me@example.com>, Bob <bob@example.com>',
+            'Carol <carol@example.com>, me@example.com',
+            myEmail
+        );
+        expect(result.to).toEqual(['alice@example.com']);
+        expect(result.cc).toEqual(['bob@example.com', 'carol@example.com']);
+    });
+
+    it('handles empty CC header', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'recipient@example.com',
+            '',
+            myEmail
+        );
+        expect(result.cc).toEqual(['recipient@example.com']);
+    });
+
+    it('is case insensitive when excluding authenticated user', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'ME@EXAMPLE.COM, other@example.com',
+            '',
+            myEmail
+        );
+        expect(result.cc).toEqual(['other@example.com']);
+    });
+});

--- a/src/reply-all-helpers.ts
+++ b/src/reply-all-helpers.ts
@@ -1,0 +1,111 @@
+/**
+ * Helper functions for reply_all email functionality.
+ * Extracted for testability.
+ */
+
+/**
+ * Parses email addresses from a header value.
+ * Handles formats like:
+ * - "email@example.com"
+ * - "Name <email@example.com>"
+ * - Multiple addresses separated by commas
+ *
+ * @param headerValue - The raw header value (e.g., From, To, CC)
+ * @returns Array of extracted email addresses
+ */
+export function parseEmailAddresses(headerValue: string): string[] {
+    if (!headerValue) return [];
+
+    const emails: string[] = [];
+    const parts = headerValue.split(',');
+
+    for (const part of parts) {
+        const trimmed = part.trim();
+        // Extract email from "Name <email>" format
+        const match = trimmed.match(/<([^>]+)>/);
+        if (match) {
+            emails.push(match[1].trim());
+        } else if (trimmed.includes('@')) {
+            emails.push(trimmed);
+        }
+    }
+
+    return emails;
+}
+
+/**
+ * Filters out the authenticated user's email from a list of emails.
+ * Case-insensitive comparison.
+ *
+ * @param emails - Array of email addresses to filter
+ * @param myEmail - The authenticated user's email address
+ * @returns Filtered array excluding the user's email
+ */
+export function filterOutEmail(emails: string[], myEmail: string): string[] {
+    const myEmailLower = myEmail.toLowerCase();
+    return emails.filter(email => email.toLowerCase() !== myEmailLower);
+}
+
+/**
+ * Adds "Re: " prefix to a subject if not already present.
+ * Case-insensitive check for existing prefix.
+ *
+ * @param subject - The original email subject
+ * @returns Subject with "Re: " prefix
+ */
+export function addRePrefix(subject: string): string {
+    if (subject.toLowerCase().startsWith('re:')) {
+        return subject;
+    }
+    return `Re: ${subject}`;
+}
+
+/**
+ * Builds the References header for a reply email.
+ * Combines original References with original Message-ID.
+ *
+ * @param originalReferences - The References header from the original email
+ * @param originalMessageId - The Message-ID of the original email
+ * @returns Combined References header value
+ */
+export function buildReferencesHeader(originalReferences: string, originalMessageId: string): string {
+    if (!originalMessageId) {
+        return originalReferences;
+    }
+    return originalReferences ? `${originalReferences} ${originalMessageId}` : originalMessageId;
+}
+
+/**
+ * Builds recipient lists for a reply-all email.
+ *
+ * Rules:
+ * - TO: original From (sender of the email)
+ * - CC: original To + original CC (excluding the authenticated user)
+ *
+ * @param originalFrom - From header value
+ * @param originalTo - To header value
+ * @param originalCc - CC header value
+ * @param myEmail - The authenticated user's email address
+ * @returns Object with 'to' and 'cc' arrays
+ */
+export function buildReplyAllRecipients(
+    originalFrom: string,
+    originalTo: string,
+    originalCc: string,
+    myEmail: string
+): { to: string[]; cc: string[] } {
+    const fromEmails = parseEmailAddresses(originalFrom);
+    const toEmails = parseEmailAddresses(originalTo);
+    const ccEmails = parseEmailAddresses(originalCc);
+
+    // TO recipients: original From (the person who sent the email), excluding myself
+    const replyTo = filterOutEmail(fromEmails, myEmail);
+
+    // CC recipients: everyone else who was on To and CC, excluding myself
+    const replyCc = filterOutEmail([...toEmails, ...ccEmails], myEmail);
+
+    return {
+        to: replyTo,
+        cc: replyCc
+    };
+}


### PR DESCRIPTION
## Summary

- Adds a new `reply_all` tool that simplifies replying to all recipients on an email thread
- Automatically fetches the original email headers (From, To, CC) to build the recipient list
- Excludes the authenticated user's email from recipients
- Sets proper threading headers (In-Reply-To, References, threadId) for correct thread grouping

## Motivation

Currently, users must manually specify all recipients when replying to an email. This is tedious and error-prone, especially for emails with multiple recipients. The `reply_all` tool automates this by:

1. Taking only a `messageId` as required input (plus the reply body)
2. Fetching the original email to extract headers
3. Building the recipient list: original sender -> To, original To/CC -> CC
4. Automatically excluding the authenticated user from recipients
5. Adding "Re:" prefix to subject if not present
6. Setting proper threading headers

## Usage

```json
{
  "messageId": "182ab45cd67ef",
  "body": "Thanks for the update! I'll review this today.",
  "htmlBody": "<p>Thanks for the update! I'll review this today.</p>",
  "mimeType": "multipart/alternative"
}
```

## Test plan

- [ ] Test reply to simple email (single sender, single recipient)
- [ ] Test reply to email with multiple CC recipients
- [ ] Test reply preserves thread grouping in Gmail
- [ ] Test subject correctly adds "Re:" prefix
- [ ] Test excludes self from CC when self was in original To
- [ ] Test with attachments

Generated with [Claude Code](https://claude.com/claude-code)