### PR TITLE
fix: use correct Gmail API response key for list filters

### DIFF
--- a/src/filter-manager.ts
+++ b/src/filter-manager.ts
@@ -67,7 +67,8 @@ export async function listFilters(gmail: any) {
             userId: 'me',
         });
 
-        const filters = response.data.filters || [];
+        // Gmail API returns 'filter' (singular), not 'filters'
+        const filters = response.data.filter || [];
         
         return {
             filters,


### PR DESCRIPTION
## Summary

The `list_filters` function returns "No filters found" even when filters exist because it reads `response.data.filters` but the Gmail API returns data under `response.data.filter` (singular).

## The Bug

```typescript
// Before (incorrect)
const filters = response.data.filters || [];

// After (correct)
const filters = response.data.filter || [];
```

## Reference

Gmail API documentation confirms the response uses `filter` (singular):
https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.filters/list

```json
{
  "filter": [
    {
      object (Filter)
    }
  ]
}
```

## Test

Before fix - returns "No filters found" with debug showing actual filters:
```
No filters found. Debug raw response: {"filter":[{"id":"ANe1Bmi...
```

After fix - correctly returns the filters.