### PR TITLE
feat: prefer HTML email body over plain text for LLM consumption

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -623,13 +623,12 @@ async function main() {
                     // Extract email content using the recursive function
                     const { text, html } = extractEmailContent(response.data.payload as GmailMessagePart || {});
 
-                    // Use plain text content if available, otherwise use HTML content
-                    // (optionally, you could implement HTML-to-text conversion here)
-                    let body = text || html || '';
-
-                    // If we only have HTML content, add a note for the user
-                    const contentTypeNote = !text && html ?
-                        '[Note: This email is HTML-formatted. Plain text version not available.]\n\n' : '';
+                    // Prefer HTML content to preserve links and formatting for LLM consumption.
+                    // Many emails (meeting invites, newsletters, notifications) only have
+                    // meaningful content in HTML. Plain text versions often strip links,
+                    // tables, and formatting that LLMs can parse effectively.
+                    let body = html || text || '';
+                    const contentTypeNote = '';
 
                     // Get attachment information
                     const attachments: EmailAttachment[] = [];


### PR DESCRIPTION
## Summary

- Changes `read_email` to prefer HTML content over plain text when both are available
- Removes the `[Note: This email is HTML-formatted]` warning prefix

## Motivation

Many emails (meeting invites, Google Meet transcripts, newsletters, notifications) only contain meaningful content in their HTML part. The plain text fallback often strips:

- **Links** (e.g., Google Doc URLs in meeting transcripts)
- **Tables** (e.g., formatted data in reports)
- **Formatting** that provides structural context

Since LLMs handle HTML natively, preferring HTML preserves this information without any downside. The previous `[Note: This email is HTML-formatted]` warning added noise without value for LLM consumers.

## Changes

`src/index.ts` lines 626-632:

```diff
-// Use plain text content if available, otherwise use HTML content
-let body = text || html || '';
-const contentTypeNote = !text && html ?
-    '[Note: This email is HTML-formatted. Plain text version not available.]\n\n' : '';
+// Prefer HTML content to preserve links and formatting for LLM consumption.
+let body = html || text || '';
+const contentTypeNote = '';
```

## Test plan

- [ ] Verify `read_email` returns HTML content when both text and HTML parts exist
- [ ] Verify `read_email` falls back to text when no HTML part exists
- [ ] Verify emails with only HTML content no longer show the `[Note: ...]` prefix