### PR TITLE
fix: auto-resolve In-Reply-To and References headers for reply threading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,7 @@ const SendEmailSchema = z.object({
     to: z.array(z.string()).describe("List of recipient email addresses"),
     subject: z.string().describe("Email subject"),
     body: z.string().describe("Email body content (used for text/plain or when htmlBody not provided)"),
+    from: z.string().optional().describe("Sender email address (must be a configured send-as alias in Gmail settings). Defaults to account's default send-as address if not specified."),
     htmlBody: z.string().optional().describe("HTML version of the email body"),
     mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
     cc: z.array(z.string()).optional().describe("List of CC recipients"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -446,8 +446,52 @@ async function main() {
 
         async function handleEmailAction(action: "send" | "draft", validatedArgs: any) {
             let message: string;
-            
+
             try {
+                // Auto-resolve threading headers when threadId is provided but inReplyTo is missing
+                if (validatedArgs.threadId && !validatedArgs.inReplyTo) {
+                    try {
+                        const threadResponse = await gmail.users.threads.get({
+                            userId: 'me',
+                            id: validatedArgs.threadId,
+                            format: 'metadata',
+                            metadataHeaders: ['Message-ID'],
+                        });
+
+                        const threadMessages = threadResponse.data.messages || [];
+                        if (threadMessages.length > 0) {
+                            // Collect all Message-ID values for the References chain
+                            const allMessageIds: string[] = [];
+                            for (const msg of threadMessages) {
+                                const msgHeaders = msg.payload?.headers || [];
+                                const messageIdHeader = msgHeaders.find(
+                                    (h) => h.name?.toLowerCase() === 'message-id'
+                                );
+                                if (messageIdHeader?.value) {
+                                    allMessageIds.push(messageIdHeader.value);
+                                }
+                            }
+
+                            // Last message's Message-ID becomes In-Reply-To
+                            const lastMessage = threadMessages[threadMessages.length - 1];
+                            const lastHeaders = lastMessage.payload?.headers || [];
+                            const lastMessageId = lastHeaders.find(
+                                (h) => h.name?.toLowerCase() === 'message-id'
+                            )?.value;
+
+                            if (lastMessageId) {
+                                validatedArgs.inReplyTo = lastMessageId;
+                            }
+                            if (allMessageIds.length > 0) {
+                                validatedArgs.references = allMessageIds.join(' ');
+                            }
+                        }
+                    } catch (threadError: any) {
+                        console.warn(`Warning: Could not fetch thread ${validatedArgs.threadId} for header resolution: ${threadError.message}`);
+                        // Continue without threading headers - degraded but not broken
+                    }
+                }
+
                 // Check if we have attachments
                 if (validatedArgs.attachments && validatedArgs.attachments.length > 0) {
                     // Use Nodemailer to create properly formatted RFC822 message
@@ -618,6 +662,7 @@ async function main() {
                     const from = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
                     const to = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
                     const date = headers.find(h => h.name?.toLowerCase() === 'date')?.value || '';
+                    const rfcMessageId = headers.find(h => h.name?.toLowerCase() === 'message-id')?.value || '';
                     const threadId = response.data.threadId || '';
 
                     // Extract email content using the recursive function
@@ -664,7 +709,7 @@ async function main() {
                         content: [
                             {
                                 type: "text",
-                                text: `Thread ID: ${threadId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
+                                text: `Thread ID: ${threadId}\nMessage-ID: ${rfcMessageId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
                             },
                         ],
                     };

--- a/src/utl.test.ts
+++ b/src/utl.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for email threading header fixes (issue #66)
+ *
+ * Verifies:
+ * 1. createEmailMessage uses separate `references` field when provided
+ * 2. createEmailMessage falls back to `inReplyTo` for References when no `references` field
+ * 3. No References/In-Reply-To headers on new emails
+ * 4. Source verification: createEmailWithNodemailer uses references field
+ * 5. Source verification: handleEmailAction auto-resolves threading headers
+ * 6. Source verification: read_email returns Message-ID
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createEmailMessage } from './utl.js';
+
+// Resolve src directory (tests run from dist/, sources are in src/)
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = path.resolve(__dirname, '..', 'src');
+
+// Helper: extract a header value from a raw MIME message string
+function getHeader(raw: string, headerName: string): string | null {
+    const regex = new RegExp(`^${headerName}:\\s*(.+)$`, 'mi');
+    const match = raw.match(regex);
+    return match ? match[1].trim() : null;
+}
+
+async function runTests() {
+    // --- Test 1: References uses separate references field ---
+    {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'Re: Thread test',
+            body: 'Reply body',
+            inReplyTo: '<msg3@example.com>',
+            references: '<msg1@example.com> <msg2@example.com> <msg3@example.com>',
+        };
+        const raw = createEmailMessage(args);
+
+        const referencesHeader = getHeader(raw, 'References');
+        assert.equal(
+            referencesHeader,
+            '<msg1@example.com> <msg2@example.com> <msg3@example.com>',
+            'References header should use the dedicated references field (full chain)'
+        );
+
+        const inReplyToHeader = getHeader(raw, 'In-Reply-To');
+        assert.equal(
+            inReplyToHeader,
+            '<msg3@example.com>',
+            'In-Reply-To should be the last message ID'
+        );
+
+        console.log('PASS: Test 1 - References uses separate references field');
+    }
+
+    // --- Test 2: References falls back to inReplyTo when references is absent ---
+    {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'Re: Fallback test',
+            body: 'Reply body',
+            inReplyTo: '<single@example.com>',
+            // no references field
+        };
+        const raw = createEmailMessage(args);
+
+        const referencesHeader = getHeader(raw, 'References');
+        assert.equal(
+            referencesHeader,
+            '<single@example.com>',
+            'References header should fall back to inReplyTo when references is absent'
+        );
+
+        console.log('PASS: Test 2 - References falls back to inReplyTo');
+    }
+
+    // --- Test 3: No References/In-Reply-To when neither is set ---
+    {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'New email',
+            body: 'Fresh email body',
+            // no inReplyTo, no references
+        };
+        const raw = createEmailMessage(args);
+
+        const referencesHeader = getHeader(raw, 'References');
+        const inReplyToHeader = getHeader(raw, 'In-Reply-To');
+        assert.equal(referencesHeader, null, 'No References header for new emails');
+        assert.equal(inReplyToHeader, null, 'No In-Reply-To header for new emails');
+
+        console.log('PASS: Test 3 - No threading headers on new emails');
+    }
+
+    // --- Test 4: Source verification - createEmailWithNodemailer uses references field ---
+    {
+        const source = fs.readFileSync(path.join(srcDir, 'utl.ts'), 'utf-8');
+
+        assert.ok(
+            source.includes('references: validatedArgs.references || validatedArgs.inReplyTo'),
+            'createEmailWithNodemailer should use references field with inReplyTo fallback'
+        );
+
+        console.log('PASS: Test 4 - Source verification: createEmailWithNodemailer references pattern');
+    }
+
+    // --- Test 5: Source verification - index.ts auto-resolves threading headers ---
+    {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+
+        assert.ok(
+            source.includes("validatedArgs.threadId && !validatedArgs.inReplyTo"),
+            'handleEmailAction should check for threadId without inReplyTo'
+        );
+        assert.ok(
+            source.includes("gmail.users.threads.get"),
+            'handleEmailAction should fetch thread metadata'
+        );
+        assert.ok(
+            source.includes("validatedArgs.inReplyTo = lastMessageId"),
+            'handleEmailAction should set inReplyTo from last message'
+        );
+        assert.ok(
+            source.includes("validatedArgs.references = allMessageIds.join(' ')"),
+            'handleEmailAction should set references from all message IDs'
+        );
+
+        console.log('PASS: Test 5 - Source verification: handleEmailAction auto-resolution');
+    }
+
+    // --- Test 6: Source verification - read_email returns Message-ID ---
+    {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+
+        assert.ok(
+            source.includes("message-id") && source.includes("rfcMessageId"),
+            'read_email handler should extract Message-ID header'
+        );
+        assert.ok(
+            source.includes('Message-ID: ${rfcMessageId}'),
+            'read_email output should include Message-ID'
+        );
+
+        console.log('PASS: Test 6 - Source verification: read_email returns Message-ID');
+    }
+
+    console.log('\nAll 6 tests passed.');
+}
+
+runTests().catch((err) => {
+    console.error('TEST FAILED:', err.message);
+    process.exit(1);
+});

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -44,7 +44,7 @@ export function createEmailMessage(validatedArgs: any): string {
 
     // Common email headers
     const emailParts = [
-        'From: me',
+        `From: ${validatedArgs.from || 'me'}`,
         `To: ${validatedArgs.to.join(', ')}`,
         validatedArgs.cc ? `Cc: ${validatedArgs.cc.join(', ')}` : '',
         validatedArgs.bcc ? `Bcc: ${validatedArgs.bcc.join(', ')}` : '',
@@ -128,7 +128,7 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
     }
 
     const mailOptions = {
-        from: 'me', // Gmail API will replace this with the authenticated user
+        from: validatedArgs.from || 'me', // Gmail API uses default send-as if 'me', or specified alias
         to: validatedArgs.to.join(', '),
         cc: validatedArgs.cc?.join(', '),
         bcc: validatedArgs.bcc?.join(', '),

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -51,7 +51,7 @@ export function createEmailMessage(validatedArgs: any): string {
         `Subject: ${encodedSubject}`,
         // Add thread-related headers if specified
         validatedArgs.inReplyTo ? `In-Reply-To: ${validatedArgs.inReplyTo}` : '',
-        validatedArgs.inReplyTo ? `References: ${validatedArgs.inReplyTo}` : '',
+        (validatedArgs.references || validatedArgs.inReplyTo) ? `References: ${validatedArgs.references || validatedArgs.inReplyTo}` : '',
         'MIME-Version: 1.0',
     ].filter(Boolean);
 
@@ -137,7 +137,7 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
         html: validatedArgs.htmlBody,
         attachments: attachments,
         inReplyTo: validatedArgs.inReplyTo,
-        references: validatedArgs.inReplyTo
+        references: validatedArgs.references || validatedArgs.inReplyTo
     };
 
     // Generate the raw message


### PR DESCRIPTION
## Summary

Fixes #66 — Email replies sent via `send_email` with `threadId` appear threaded for the sender but create **new conversations** for recipients.

**Root cause:** `threadId` only controls Gmail's internal server-side grouping. Recipients' mail servers thread based on RFC 2822 `In-Reply-To` and `References` MIME headers, which were never set when only `threadId` was provided.

## Changes

### Reply threading fix (original)
- **Auto-resolve threading headers:** When `threadId` is provided without `inReplyTo`, the tool now fetches the thread via `gmail.users.threads.get()`, extracts the last message's `Message-ID` header for `In-Reply-To`, and builds the full `References` chain from all messages in the thread.
- **Separate `references` field:** `utl.ts` now supports a dedicated `references` field (falls back to `inReplyTo` for backward compatibility).
- **Return `Message-ID` in `read_email`:** Callers can now see the RFC Message-ID header, enabling manual `inReplyTo` usage if preferred.
- **Graceful degradation:** If thread fetch fails, a warning is logged and the email sends without threading headers (same as before — no regression).

### Send-as alias support (new)
- **Optional `from` parameter:** `send_email` and `draft_email` now accept an optional `from` field to specify a configured send-as alias (e.g. `user@gmail.com` vs `ceo@company.com`). Previously hardcoded to `From: me` which always resolved to the account's default send-as address.
- **Both message builders updated:** `createEmailMessage()` and `createEmailWithNodemailer()` in `utl.ts` now use `validatedArgs.from || 'me'`.
- **No breaking changes:** When `from` is omitted, behavior is identical to before.

## Test plan

- [x] Send reply with `threadId` only (no `inReplyTo`) — recipient sees it in existing thread
- [x] Existing behavior unchanged when both `threadId` + `inReplyTo` provided
- [x] `read_email` output includes `Message-ID` header
- [x] Send email with `from` set to non-default alias — delivered with correct sender
- [x] Send email without `from` — uses default send-as (backward compatible)
- [x] Unit tests pass (6/6)
- [x] TypeScript builds cleanly

Tested with real Gmail accounts — confirmed recipient-side threading and send-as alias both work.