### PR TITLE
Add multi-account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# Gmail AutoAuth MCP Server
+# Gmail AutoAuth MCP Server (Actively Maintained Fork)
+
+> **This is an actively maintained fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server).**
+>
+> The original repository has been unmaintained since August 2025 — 7+ months with zero maintainer activity and 72+ unmerged pull requests. I use this MCP server daily as part of my Claude Code workflow and depend on it working correctly, so I picked it up.
+>
+> **Pull requests are welcome.** If you've been sitting on fixes or features with nowhere to submit them, this is the place.
+
+### What this fork adds
+
+- **Fixed reply threading** — auto-resolves `In-Reply-To` and `References` headers so email replies land in the correct thread instead of creating orphaned messages ([upstream PR #91](https://github.com/GongRzhe/Gmail-MCP-Server/pull/91), still pending)
+- **Send-as alias support** — optional `from` parameter for multi-identity email management (send from any configured Gmail alias)
+
+Both features are production-tested in daily use.
+
+---
 
 A Model Context Protocol (MCP) server for Gmail integration in Claude Desktop with auto authentication support. This server enables AI assistants to manage Gmail through natural language interactions.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Model Context Protocol (MCP) server for Gmail integration in Claude Desktop wi
 
 ## Features
 
+- **Multi-account support** - manage multiple Gmail accounts from a single server instance
 - Send emails with subject, content, **attachments**, and recipients
 - **Full attachment support** - send and receive file attachments
 - **Download email attachments** to local filesystem
@@ -194,11 +195,66 @@ npx @gongrzhe/server-gmail-autoauth-mcp auth https://gmail.gongrzhe.com/oauth2ca
 
 This approach allows authentication flows to work properly in environments where localhost isn't accessible, such as containerized applications or cloud servers.
 
+## Multi-Account Support
+
+You can configure multiple Gmail accounts and switch between them using the optional `account` parameter on any tool.
+
+### Authenticating Additional Accounts
+
+```bash
+# Authenticate your default account (same as before)
+npx @gongrzhe/server-gmail-autoauth-mcp auth
+
+# Authenticate a "work" account
+npx @gongrzhe/server-gmail-autoauth-mcp auth work
+
+# Authenticate a "personal" account
+npx @gongrzhe/server-gmail-autoauth-mcp auth personal
+
+# With custom callback URL for cloud environments
+npx @gongrzhe/server-gmail-autoauth-mcp auth work https://gmail.example.com/oauth2callback
+```
+
+Credentials are stored as:
+- `~/.gmail-mcp/credentials.json` - "default" account
+- `~/.gmail-mcp/credentials-work.json` - "work" account
+- `~/.gmail-mcp/credentials-personal.json` - "personal" account
+
+### Using Multiple Accounts
+
+All tools accept an optional `account` parameter. Omit it to use the default account:
+
+```json
+// Search default account
+{ "query": "from:boss@company.com" }
+
+// Search work account
+{ "query": "from:boss@company.com", "account": "work" }
+
+// Search personal account
+{ "query": "from:friend@gmail.com", "account": "personal" }
+```
+
+Use `list_accounts` to see all configured accounts.
+
+### Backwards Compatibility
+
+- Existing single-account setups work without any changes
+- The `GMAIL_CREDENTIALS_PATH` environment variable still works (loads as "default")
+- All tools work without the `account` parameter (uses default)
+
 ## Available Tools
 
 The server provides the following tools that can be used through Claude Desktop:
 
-### 1. Send Email (`send_email`)
+### 1. List Accounts (`list_accounts`)
+Lists all configured Gmail accounts.
+
+```json
+{}
+```
+
+### 2. Send Email (`send_email`)
 
 Sends a new email immediately. Supports plain text, HTML, or multipart emails **with optional file attachments**.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,7 @@ const SendEmailSchema = z.object({
     to: z.array(z.string()).describe("List of recipient email addresses"),
     subject: z.string().describe("Email subject"),
     body: z.string().describe("Email body content (used for text/plain or when htmlBody not provided)"),
+    from: z.string().optional().describe("Sender email address (must be a configured send-as alias in Gmail settings). Defaults to account's default send-as address if not specified."),
     htmlBody: z.string().optional().describe("HTML version of the email body"),
     mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
     cc: z.array(z.string()).optional().describe("List of CC recipients"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // Configuration paths
 const CONFIG_DIR = path.join(os.homedir(), '.gmail-mcp');
 const OAUTH_PATH = process.env.GMAIL_OAUTH_PATH || path.join(CONFIG_DIR, 'gcp-oauth.keys.json');
-const CREDENTIALS_PATH = process.env.GMAIL_CREDENTIALS_PATH || path.join(CONFIG_DIR, 'credentials.json');
+// Multi-account support
+const gmailClients: Map<string, ReturnType<typeof google.gmail>> = new Map();
+const defaultAccount = 'default';
 
 // Type definitions for Gmail API responses
 interface GmailMessagePart {
@@ -56,8 +58,53 @@ interface EmailContent {
     html: string;
 }
 
-// OAuth2 configuration
-let oauth2Client: OAuth2Client;
+function getCredentialsPath(accountName: string): string {
+	if (accountName === 'default') {
+		return path.join(CONFIG_DIR, 'credentials.json');
+	}
+	return path.join(CONFIG_DIR, `credentials-${accountName}.json`);
+}
+
+function getOAuth2Client(callbackUrl?: string): OAuth2Client {
+	const localOAuthPath = path.join(process.cwd(), 'gcp-oauth.keys.json');
+
+	if (fs.existsSync(localOAuthPath) && !fs.existsSync(OAUTH_PATH)) {
+		if (!fs.existsSync(CONFIG_DIR)) {
+			fs.mkdirSync(CONFIG_DIR, { recursive: true });
+		}
+		fs.copyFileSync(localOAuthPath, OAUTH_PATH);
+		console.log('OAuth keys found in current directory, copied to global config.');
+	}
+
+	if (!fs.existsSync(OAUTH_PATH)) {
+		console.error('Error: OAuth keys file not found. Please place gcp-oauth.keys.json in current directory or', CONFIG_DIR);
+		process.exit(1);
+	}
+
+	const keysContent = JSON.parse(fs.readFileSync(OAUTH_PATH, 'utf8'));
+	const keys = keysContent.installed || keysContent.web;
+
+	if (!keys) {
+		console.error('Error: Invalid OAuth keys file format. File should contain either "installed" or "web" credentials.');
+		process.exit(1);
+	}
+
+	return new OAuth2Client(
+		keys.client_id,
+		keys.client_secret,
+		callbackUrl || "http://localhost:3000/oauth2callback"
+	);
+}
+
+function getGmailClient(account?: string) {
+	const name = account || defaultAccount;
+	const client = gmailClients.get(name);
+	if (!client) {
+		const available = Array.from(gmailClients.keys()).join(', ');
+		throw new Error(`Account "${name}" not found. Available: ${available}`);
+	}
+	return client;
+}
 
 /**
  * Recursively extract email body content from MIME message parts
@@ -93,101 +140,116 @@ function extractEmailContent(messagePart: GmailMessagePart): EmailContent {
     return { text: textContent, html: htmlContent };
 }
 
-async function loadCredentials() {
-    try {
-        // Create config directory if it doesn't exist
-        if (!process.env.GMAIL_OAUTH_PATH && !CREDENTIALS_PATH &&!fs.existsSync(CONFIG_DIR)) {
-            fs.mkdirSync(CONFIG_DIR, { recursive: true });
-        }
+async function loadAllAccounts() {
+	if (!fs.existsSync(CONFIG_DIR)) {
+		fs.mkdirSync(CONFIG_DIR, { recursive: true });
+	}
 
-        // Check for OAuth keys in current directory first, then in config directory
-        const localOAuthPath = path.join(process.cwd(), 'gcp-oauth.keys.json');
-        let oauthPath = OAUTH_PATH;
+	// If GMAIL_CREDENTIALS_PATH env var is set, load just that as "default"
+	if (process.env.GMAIL_CREDENTIALS_PATH) {
+		const credPath = process.env.GMAIL_CREDENTIALS_PATH;
+		if (fs.existsSync(credPath)) {
+			try {
+				const client = getOAuth2Client();
+				const credentials = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+				client.setCredentials(credentials);
+				gmailClients.set('default', google.gmail({ version: 'v1', auth: client }));
+			} catch (error) {
+				console.error('Failed to load credentials from GMAIL_CREDENTIALS_PATH:', error);
+			}
+		}
+		return;
+	}
 
-        if (fs.existsSync(localOAuthPath)) {
-            // If found in current directory, copy to config directory
-            fs.copyFileSync(localOAuthPath, OAUTH_PATH);
-            console.log('OAuth keys found in current directory, copied to global config.');
-        }
+	// Glob credentials files in config dir
+	const files = fs.readdirSync(CONFIG_DIR).filter(f => /^credentials(-[\w-]+)?\.json$/.test(f));
 
-        if (!fs.existsSync(OAUTH_PATH)) {
-            console.error('Error: OAuth keys file not found. Please place gcp-oauth.keys.json in current directory or', CONFIG_DIR);
-            process.exit(1);
-        }
+	for (const file of files) {
+		const match = file.match(/^credentials(?:-([\w-]+))?\.json$/);
+		if (!match) continue;
 
-        const keysContent = JSON.parse(fs.readFileSync(OAUTH_PATH, 'utf8'));
-        const keys = keysContent.installed || keysContent.web;
+		const accountName = match[1] || 'default';
+		const credPath = path.join(CONFIG_DIR, file);
 
-        if (!keys) {
-            console.error('Error: Invalid OAuth keys file format. File should contain either "installed" or "web" credentials.');
-            process.exit(1);
-        }
+		try {
+			const client = getOAuth2Client();
+			const credentials = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+			client.setCredentials(credentials);
+			gmailClients.set(accountName, google.gmail({ version: 'v1', auth: client }));
+		} catch (error) {
+			console.error(`Failed to load account "${accountName}":`, error);
+		}
+	}
 
-        const callback = process.argv[2] === 'auth' && process.argv[3] 
-        ? process.argv[3] 
-        : "http://localhost:3000/oauth2callback";
-
-        oauth2Client = new OAuth2Client(
-            keys.client_id,
-            keys.client_secret,
-            callback
-        );
-
-        if (fs.existsSync(CREDENTIALS_PATH)) {
-            const credentials = JSON.parse(fs.readFileSync(CREDENTIALS_PATH, 'utf8'));
-            oauth2Client.setCredentials(credentials);
-        }
-    } catch (error) {
-        console.error('Error loading credentials:', error);
-        process.exit(1);
-    }
+	if (gmailClients.size === 0) {
+		console.error('No Gmail accounts configured. Run "npm run auth" first.');
+	}
 }
 
-async function authenticate() {
-    const server = http.createServer();
-    server.listen(3000);
+async function authenticate(accountName?: string, callbackUrl?: string) {
+	const name = accountName || 'default';
+	const credPath = getCredentialsPath(name);
 
-    return new Promise<void>((resolve, reject) => {
-        const authUrl = oauth2Client.generateAuthUrl({
-            access_type: 'offline',
-            scope: [
-                'https://www.googleapis.com/auth/gmail.modify',
-                'https://www.googleapis.com/auth/gmail.settings.basic'
-            ],
-        });
+	if (!fs.existsSync(CONFIG_DIR)) {
+		fs.mkdirSync(CONFIG_DIR, { recursive: true });
+	}
 
-        console.log('Please visit this URL to authenticate:', authUrl);
-        open(authUrl);
+	const oauth2Client = getOAuth2Client(callbackUrl);
 
-        server.on('request', async (req, res) => {
-            if (!req.url?.startsWith('/oauth2callback')) return;
+	const httpServer = http.createServer();
+	httpServer.listen(3000);
 
-            const url = new URL(req.url, 'http://localhost:3000');
-            const code = url.searchParams.get('code');
+	return new Promise<void>((resolve, reject) => {
+		const authUrl = oauth2Client.generateAuthUrl({
+			access_type: 'offline',
+			scope: [
+				'https://www.googleapis.com/auth/gmail.modify',
+				'https://www.googleapis.com/auth/gmail.settings.basic'
+			],
+		});
 
-            if (!code) {
-                res.writeHead(400);
-                res.end('No code provided');
-                reject(new Error('No code provided'));
-                return;
-            }
+		console.log(`Authenticating account "${name}"...`);
+		console.log('Please visit this URL to authenticate:', authUrl);
+		open(authUrl);
 
-            try {
-                const { tokens } = await oauth2Client.getToken(code);
-                oauth2Client.setCredentials(tokens);
-                fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(tokens));
+		httpServer.on('request', async (req, res) => {
+			if (!req.url?.startsWith('/oauth2callback')) return;
 
-                res.writeHead(200);
-                res.end('Authentication successful! You can close this window.');
-                server.close();
-                resolve();
-            } catch (error) {
-                res.writeHead(500);
-                res.end('Authentication failed');
-                reject(error);
-            }
-        });
-    });
+			const url = new URL(req.url, 'http://localhost:3000');
+			const code = url.searchParams.get('code');
+
+			if (!code) {
+				res.writeHead(400);
+				res.end('No code provided');
+				reject(new Error('No code provided'));
+				return;
+			}
+
+			try {
+				const { tokens } = await oauth2Client.getToken(code);
+				oauth2Client.setCredentials(tokens);
+				fs.writeFileSync(credPath, JSON.stringify(tokens));
+
+				res.writeHead(200);
+				res.end(`Authentication successful for account "${name}"! You can close this window.`);
+				httpServer.close();
+				resolve();
+			} catch (error) {
+				res.writeHead(500);
+				res.end('Authentication failed');
+				reject(error);
+			}
+		});
+	});
+}
+
+// Account parameter added to all tool schemas for multi-account support
+const AccountParam = {
+	account: z.string().optional().describe("Gmail account name. Omit for default. Use list_accounts to see available."),
+};
+
+function withAccountParam<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
+	return schema.extend(AccountParam);
 }
 
 // Schema definitions
@@ -321,16 +383,24 @@ const DownloadAttachmentSchema = z.object({
 
 // Main function
 async function main() {
-    await loadCredentials();
-
     if (process.argv[2] === 'auth') {
-        await authenticate();
+        let accountName: string | undefined;
+        let callbackUrl: string | undefined;
+
+        for (const arg of process.argv.slice(3)) {
+            if (arg.startsWith('http')) {
+                callbackUrl = arg;
+            } else {
+                accountName = arg;
+            }
+        }
+
+        await authenticate(accountName, callbackUrl);
         console.log('Authentication completed successfully');
         process.exit(0);
     }
 
-    // Initialize Gmail API
-    const gmail = google.gmail({ version: 'v1', auth: oauth2Client });
+    await loadAllAccounts();
 
     // Server implementation
     const server = new Server({
@@ -345,105 +415,132 @@ async function main() {
     server.setRequestHandler(ListToolsRequestSchema, async () => ({
         tools: [
             {
+                name: "list_accounts",
+                description: "Lists all configured Gmail accounts",
+                inputSchema: zodToJsonSchema(z.object({})),
+            },
+            {
                 name: "send_email",
                 description: "Sends a new email",
-                inputSchema: zodToJsonSchema(SendEmailSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(SendEmailSchema)),
             },
             {
                 name: "draft_email",
                 description: "Draft a new email",
-                inputSchema: zodToJsonSchema(SendEmailSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(SendEmailSchema)),
             },
             {
                 name: "read_email",
                 description: "Retrieves the content of a specific email",
-                inputSchema: zodToJsonSchema(ReadEmailSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(ReadEmailSchema)),
             },
             {
                 name: "search_emails",
                 description: "Searches for emails using Gmail search syntax",
-                inputSchema: zodToJsonSchema(SearchEmailsSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(SearchEmailsSchema)),
             },
             {
                 name: "modify_email",
                 description: "Modifies email labels (move to different folders)",
-                inputSchema: zodToJsonSchema(ModifyEmailSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(ModifyEmailSchema)),
             },
             {
                 name: "delete_email",
                 description: "Permanently deletes an email",
-                inputSchema: zodToJsonSchema(DeleteEmailSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(DeleteEmailSchema)),
             },
             {
                 name: "list_email_labels",
                 description: "Retrieves all available Gmail labels",
-                inputSchema: zodToJsonSchema(ListEmailLabelsSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(ListEmailLabelsSchema)),
             },
             {
                 name: "batch_modify_emails",
                 description: "Modifies labels for multiple emails in batches",
-                inputSchema: zodToJsonSchema(BatchModifyEmailsSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(BatchModifyEmailsSchema)),
             },
             {
                 name: "batch_delete_emails",
                 description: "Permanently deletes multiple emails in batches",
-                inputSchema: zodToJsonSchema(BatchDeleteEmailsSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(BatchDeleteEmailsSchema)),
             },
             {
                 name: "create_label",
                 description: "Creates a new Gmail label",
-                inputSchema: zodToJsonSchema(CreateLabelSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(CreateLabelSchema)),
             },
             {
                 name: "update_label",
                 description: "Updates an existing Gmail label",
-                inputSchema: zodToJsonSchema(UpdateLabelSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(UpdateLabelSchema)),
             },
             {
                 name: "delete_label",
                 description: "Deletes a Gmail label",
-                inputSchema: zodToJsonSchema(DeleteLabelSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(DeleteLabelSchema)),
             },
             {
                 name: "get_or_create_label",
                 description: "Gets an existing label by name or creates it if it doesn't exist",
-                inputSchema: zodToJsonSchema(GetOrCreateLabelSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(GetOrCreateLabelSchema)),
             },
             {
                 name: "create_filter",
                 description: "Creates a new Gmail filter with custom criteria and actions",
-                inputSchema: zodToJsonSchema(CreateFilterSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(CreateFilterSchema)),
             },
             {
                 name: "list_filters",
                 description: "Retrieves all Gmail filters",
-                inputSchema: zodToJsonSchema(ListFiltersSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(ListFiltersSchema)),
             },
             {
                 name: "get_filter",
                 description: "Gets details of a specific Gmail filter",
-                inputSchema: zodToJsonSchema(GetFilterSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(GetFilterSchema)),
             },
             {
                 name: "delete_filter",
                 description: "Deletes a Gmail filter",
-                inputSchema: zodToJsonSchema(DeleteFilterSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(DeleteFilterSchema)),
             },
             {
                 name: "create_filter_from_template",
                 description: "Creates a filter using a pre-defined template for common scenarios",
-                inputSchema: zodToJsonSchema(CreateFilterFromTemplateSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(CreateFilterFromTemplateSchema)),
             },
             {
                 name: "download_attachment",
                 description: "Downloads an email attachment to a specified location",
-                inputSchema: zodToJsonSchema(DownloadAttachmentSchema),
+                inputSchema: zodToJsonSchema(withAccountParam(DownloadAttachmentSchema)),
             },
         ],
     }))
 
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { name, arguments: args } = request.params;
+
+        // Handle list_accounts before resolving gmail client
+        if (name === 'list_accounts') {
+            const accounts = Array.from(gmailClients.keys());
+            const accountList = accounts.map(a =>
+                a === defaultAccount ? `${a} (default)` : a
+            ).join('\n');
+
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: accounts.length > 0
+                            ? `Configured accounts:\n${accountList}`
+                            : 'No accounts configured. Run auth first.',
+                    },
+                ],
+            };
+        }
+
+        const account = (args as any)?.account as string | undefined;
+        const gmail = getGmailClient(account);
 
         async function handleEmailAction(action: "send" | "draft", validatedArgs: any) {
             let message: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -446,8 +446,52 @@ async function main() {
 
         async function handleEmailAction(action: "send" | "draft", validatedArgs: any) {
             let message: string;
-            
+
             try {
+                // Auto-resolve threading headers when threadId is provided but inReplyTo is missing
+                if (validatedArgs.threadId && !validatedArgs.inReplyTo) {
+                    try {
+                        const threadResponse = await gmail.users.threads.get({
+                            userId: 'me',
+                            id: validatedArgs.threadId,
+                            format: 'metadata',
+                            metadataHeaders: ['Message-ID'],
+                        });
+
+                        const threadMessages = threadResponse.data.messages || [];
+                        if (threadMessages.length > 0) {
+                            // Collect all Message-ID values for the References chain
+                            const allMessageIds: string[] = [];
+                            for (const msg of threadMessages) {
+                                const msgHeaders = msg.payload?.headers || [];
+                                const messageIdHeader = msgHeaders.find(
+                                    (h) => h.name?.toLowerCase() === 'message-id'
+                                );
+                                if (messageIdHeader?.value) {
+                                    allMessageIds.push(messageIdHeader.value);
+                                }
+                            }
+
+                            // Last message's Message-ID becomes In-Reply-To
+                            const lastMessage = threadMessages[threadMessages.length - 1];
+                            const lastHeaders = lastMessage.payload?.headers || [];
+                            const lastMessageId = lastHeaders.find(
+                                (h) => h.name?.toLowerCase() === 'message-id'
+                            )?.value;
+
+                            if (lastMessageId) {
+                                validatedArgs.inReplyTo = lastMessageId;
+                            }
+                            if (allMessageIds.length > 0) {
+                                validatedArgs.references = allMessageIds.join(' ');
+                            }
+                        }
+                    } catch (threadError: any) {
+                        console.warn(`Warning: Could not fetch thread ${validatedArgs.threadId} for header resolution: ${threadError.message}`);
+                        // Continue without threading headers - degraded but not broken
+                    }
+                }
+
                 // Check if we have attachments
                 if (validatedArgs.attachments && validatedArgs.attachments.length > 0) {
                     // Use Nodemailer to create properly formatted RFC822 message
@@ -618,6 +662,7 @@ async function main() {
                     const from = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
                     const to = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
                     const date = headers.find(h => h.name?.toLowerCase() === 'date')?.value || '';
+                    const rfcMessageId = headers.find(h => h.name?.toLowerCase() === 'message-id')?.value || '';
                     const threadId = response.data.threadId || '';
 
                     // Extract email content using the recursive function
@@ -664,7 +709,7 @@ async function main() {
                         content: [
                             {
                                 type: "text",
-                                text: `Thread ID: ${threadId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
+                                text: `Thread ID: ${threadId}\nMessage-ID: ${rfcMessageId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
                             },
                         ],
                     };

--- a/src/utl.test.ts
+++ b/src/utl.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for email threading header fixes (issue #66)
+ *
+ * Verifies:
+ * 1. createEmailMessage uses separate `references` field when provided
+ * 2. createEmailMessage falls back to `inReplyTo` for References when no `references` field
+ * 3. No References/In-Reply-To headers on new emails
+ * 4. Source verification: createEmailWithNodemailer uses references field
+ * 5. Source verification: handleEmailAction auto-resolves threading headers
+ * 6. Source verification: read_email returns Message-ID
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createEmailMessage } from './utl.js';
+
+// Resolve src directory (tests run from dist/, sources are in src/)
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = path.resolve(__dirname, '..', 'src');
+
+// Helper: extract a header value from a raw MIME message string
+function getHeader(raw: string, headerName: string): string | null {
+    const regex = new RegExp(`^${headerName}:\\s*(.+)$`, 'mi');
+    const match = raw.match(regex);
+    return match ? match[1].trim() : null;
+}
+
+async function runTests() {
+    // --- Test 1: References uses separate references field ---
+    {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'Re: Thread test',
+            body: 'Reply body',
+            inReplyTo: '<msg3@example.com>',
+            references: '<msg1@example.com> <msg2@example.com> <msg3@example.com>',
+        };
+        const raw = createEmailMessage(args);
+
+        const referencesHeader = getHeader(raw, 'References');
+        assert.equal(
+            referencesHeader,
+            '<msg1@example.com> <msg2@example.com> <msg3@example.com>',
+            'References header should use the dedicated references field (full chain)'
+        );
+
+        const inReplyToHeader = getHeader(raw, 'In-Reply-To');
+        assert.equal(
+            inReplyToHeader,
+            '<msg3@example.com>',
+            'In-Reply-To should be the last message ID'
+        );
+
+        console.log('PASS: Test 1 - References uses separate references field');
+    }
+
+    // --- Test 2: References falls back to inReplyTo when references is absent ---
+    {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'Re: Fallback test',
+            body: 'Reply body',
+            inReplyTo: '<single@example.com>',
+            // no references field
+        };
+        const raw = createEmailMessage(args);
+
+        const referencesHeader = getHeader(raw, 'References');
+        assert.equal(
+            referencesHeader,
+            '<single@example.com>',
+            'References header should fall back to inReplyTo when references is absent'
+        );
+
+        console.log('PASS: Test 2 - References falls back to inReplyTo');
+    }
+
+    // --- Test 3: No References/In-Reply-To when neither is set ---
+    {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'New email',
+            body: 'Fresh email body',
+            // no inReplyTo, no references
+        };
+        const raw = createEmailMessage(args);
+
+        const referencesHeader = getHeader(raw, 'References');
+        const inReplyToHeader = getHeader(raw, 'In-Reply-To');
+        assert.equal(referencesHeader, null, 'No References header for new emails');
+        assert.equal(inReplyToHeader, null, 'No In-Reply-To header for new emails');
+
+        console.log('PASS: Test 3 - No threading headers on new emails');
+    }
+
+    // --- Test 4: Source verification - createEmailWithNodemailer uses references field ---
+    {
+        const source = fs.readFileSync(path.join(srcDir, 'utl.ts'), 'utf-8');
+
+        assert.ok(
+            source.includes('references: validatedArgs.references || validatedArgs.inReplyTo'),
+            'createEmailWithNodemailer should use references field with inReplyTo fallback'
+        );
+
+        console.log('PASS: Test 4 - Source verification: createEmailWithNodemailer references pattern');
+    }
+
+    // --- Test 5: Source verification - index.ts auto-resolves threading headers ---
+    {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+
+        assert.ok(
+            source.includes("validatedArgs.threadId && !validatedArgs.inReplyTo"),
+            'handleEmailAction should check for threadId without inReplyTo'
+        );
+        assert.ok(
+            source.includes("gmail.users.threads.get"),
+            'handleEmailAction should fetch thread metadata'
+        );
+        assert.ok(
+            source.includes("validatedArgs.inReplyTo = lastMessageId"),
+            'handleEmailAction should set inReplyTo from last message'
+        );
+        assert.ok(
+            source.includes("validatedArgs.references = allMessageIds.join(' ')"),
+            'handleEmailAction should set references from all message IDs'
+        );
+
+        console.log('PASS: Test 5 - Source verification: handleEmailAction auto-resolution');
+    }
+
+    // --- Test 6: Source verification - read_email returns Message-ID ---
+    {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+
+        assert.ok(
+            source.includes("message-id") && source.includes("rfcMessageId"),
+            'read_email handler should extract Message-ID header'
+        );
+        assert.ok(
+            source.includes('Message-ID: ${rfcMessageId}'),
+            'read_email output should include Message-ID'
+        );
+
+        console.log('PASS: Test 6 - Source verification: read_email returns Message-ID');
+    }
+
+    console.log('\nAll 6 tests passed.');
+}
+
+runTests().catch((err) => {
+    console.error('TEST FAILED:', err.message);
+    process.exit(1);
+});

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -44,7 +44,7 @@ export function createEmailMessage(validatedArgs: any): string {
 
     // Common email headers
     const emailParts = [
-        'From: me',
+        `From: ${validatedArgs.from || 'me'}`,
         `To: ${validatedArgs.to.join(', ')}`,
         validatedArgs.cc ? `Cc: ${validatedArgs.cc.join(', ')}` : '',
         validatedArgs.bcc ? `Bcc: ${validatedArgs.bcc.join(', ')}` : '',
@@ -128,7 +128,7 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
     }
 
     const mailOptions = {
-        from: 'me', // Gmail API will replace this with the authenticated user
+        from: validatedArgs.from || 'me', // Gmail API uses default send-as if 'me', or specified alias
         to: validatedArgs.to.join(', '),
         cc: validatedArgs.cc?.join(', '),
         bcc: validatedArgs.bcc?.join(', '),

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -51,7 +51,7 @@ export function createEmailMessage(validatedArgs: any): string {
         `Subject: ${encodedSubject}`,
         // Add thread-related headers if specified
         validatedArgs.inReplyTo ? `In-Reply-To: ${validatedArgs.inReplyTo}` : '',
-        validatedArgs.inReplyTo ? `References: ${validatedArgs.inReplyTo}` : '',
+        (validatedArgs.references || validatedArgs.inReplyTo) ? `References: ${validatedArgs.references || validatedArgs.inReplyTo}` : '',
         'MIME-Version: 1.0',
     ].filter(Boolean);
 
@@ -137,7 +137,7 @@ export async function createEmailWithNodemailer(validatedArgs: any): Promise<str
         html: validatedArgs.htmlBody,
         attachments: attachments,
         inReplyTo: validatedArgs.inReplyTo,
-        references: validatedArgs.inReplyTo
+        references: validatedArgs.references || validatedArgs.inReplyTo
     };
 
     // Generate the raw message


### PR DESCRIPTION
## Summary

- Adds multi-account support to manage multiple Gmail accounts from a single server instance (resolves #19)
- Every tool now accepts an optional `account` parameter; omitting it uses the default account for full backwards compatibility
- New `list_accounts` tool to show all configured accounts

## How It Works

**Credential naming convention:**
- `~/.gmail-mcp/credentials.json` → "default" account (existing, unchanged)
- `~/.gmail-mcp/credentials-work.json` → "work"
- `~/.gmail-mcp/credentials-personal.json` → "personal"

**Auth additional accounts:**
```bash
node dist/index.js auth work
node dist/index.js auth personal
```

**Use in tool calls:**
```json
{ "query": "from:boss@company.com", "account": "work" }
```

## Backwards Compatibility

- Existing single-account setups work without any changes
- `GMAIL_CREDENTIALS_PATH` env var still works (loads as "default")
- All tools work without `account` parameter (uses default)
- `node dist/index.js auth` still authenticates the default account
- Custom callback URLs for cloud auth still work: `node dist/index.js auth work https://example.com/callback`

## Changes

- `src/index.ts`: Replace singleton OAuth2Client with per-account Gmail client map, add `account` param to all 19 tool schemas, add `list_accounts` tool
- `README.md`: Multi-account documentation

## Test plan

- [ ] `npm run build` compiles without errors
- [ ] Existing credentials work: `search_emails` without `account` param returns results
- [ ] Auth new account: `node dist/index.js auth test-account` saves `credentials-test-account.json`
- [ ] `list_accounts` shows all configured accounts
- [ ] `search_emails` with `account` param queries the specified account
- [ ] Invalid account name returns helpful error with available accounts listed
- [ ] `GMAIL_CREDENTIALS_PATH` env var still works for Docker/container setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)