### PR TITLE
Add custom OAuth2 scoping to enable granular permissioning (ex, read only)

### DIFF
--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -1,0 +1,75 @@
+// Gmail API OAuth2 scope definitions and helpers
+//
+// Scope hierarchy (for reference):
+//   - gmail.readonly: Read-only access to emails
+//   - gmail.modify: Read AND write access (superset of readonly)
+//   - gmail.compose: Create drafts and send emails
+//   - gmail.send: Send emails only
+//   - gmail.labels: Manage labels only
+//   - gmail.settings.basic: Manage filters and settings
+//
+// Note: gmail.modify includes all capabilities of gmail.readonly,
+// so you don't need both scopes together.
+
+// Map shorthand scope names to full Google API URLs
+export const SCOPE_MAP: Record<string, string> = {
+  "gmail.readonly": "https://www.googleapis.com/auth/gmail.readonly",
+  "gmail.modify": "https://www.googleapis.com/auth/gmail.modify",
+  "gmail.compose": "https://www.googleapis.com/auth/gmail.compose",
+  "gmail.send": "https://www.googleapis.com/auth/gmail.send",
+  "gmail.labels": "https://www.googleapis.com/auth/gmail.labels",
+  "gmail.settings.basic": "https://www.googleapis.com/auth/gmail.settings.basic",
+  "gmail.settings.sharing": "https://www.googleapis.com/auth/gmail.settings.sharing",
+};
+
+// Reverse map for converting full URLs back to shorthand
+export const SCOPE_REVERSE_MAP: Record<string, string> = Object.fromEntries(
+  Object.entries(SCOPE_MAP).map(([short, full]) => [full, short])
+);
+
+// Default scopes (original behavior)
+export const DEFAULT_SCOPES = ["gmail.modify", "gmail.settings.basic"];
+
+// Convert shorthand scope name to full Google API URL
+// e.g., "gmail.readonly" -> "https://www.googleapis.com/auth/gmail.readonly"
+export function scopeNameToUrl(scope: string): string {
+  return SCOPE_MAP[scope] || scope;
+}
+
+// Convert full Google API URL to shorthand name
+// e.g., "https://www.googleapis.com/auth/gmail.readonly" -> "gmail.readonly"
+export function scopeUrlToName(scope: string): string {
+  return SCOPE_REVERSE_MAP[scope] || scope;
+}
+
+// Convert array of shorthand scope names to full Google API URLs
+export function scopeNamesToUrls(scopes: string[]): string[] {
+  return scopes.map(scopeNameToUrl);
+}
+
+// Check if the authorized scopes grant access to a tool
+// Returns true if ANY of the tool's required scopes are present in authorizedScopes
+export function hasScope(authorizedScopes: string[], requiredScopes: string[]): boolean {
+  // Normalize to shorthand names for comparison (handles both URL and shorthand input)
+  const normalizedAuth = authorizedScopes.map(scopeUrlToName);
+  return requiredScopes.some(scope => normalizedAuth.includes(scope));
+}
+
+// Parse scope input from CLI (comma-separated or space-separated)
+export function parseScopes(input: string): string[] {
+  return input
+    .split(/[,\s]+/)
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+}
+
+// Validate that all scopes are recognized
+export function validateScopes(scopes: string[]): { valid: boolean; invalid: string[] } {
+  const invalid = scopes.filter(s => !SCOPE_MAP[s]);
+  return { valid: invalid.length === 0, invalid };
+}
+
+// Get available scope names for help text
+export function getAvailableScopeNames(): string[] {
+  return Object.keys(SCOPE_MAP);
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,0 +1,271 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+// Schema definitions
+export const SendEmailSchema = z.object({
+  to: z.array(z.string()).describe("List of recipient email addresses"),
+  subject: z.string().describe("Email subject"),
+  body: z.string().describe("Email body content (used for text/plain or when htmlBody not provided)"),
+  htmlBody: z.string().optional().describe("HTML version of the email body"),
+  mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
+  cc: z.array(z.string()).optional().describe("List of CC recipients"),
+  bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
+  threadId: z.string().optional().describe("Thread ID to reply to"),
+  inReplyTo: z.string().optional().describe("Message ID being replied to"),
+  attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
+});
+
+export const ReadEmailSchema = z.object({
+  messageId: z.string().describe("ID of the email message to retrieve"),
+});
+
+export const SearchEmailsSchema = z.object({
+  query: z.string().describe("Gmail search query (e.g., 'from:example@gmail.com')"),
+  maxResults: z.number().optional().describe("Maximum number of results to return"),
+});
+
+export const ModifyEmailSchema = z.object({
+  messageId: z.string().describe("ID of the email message to modify"),
+  labelIds: z.array(z.string()).optional().describe("List of label IDs to apply"),
+  addLabelIds: z.array(z.string()).optional().describe("List of label IDs to add to the message"),
+  removeLabelIds: z.array(z.string()).optional().describe("List of label IDs to remove from the message"),
+});
+
+export const DeleteEmailSchema = z.object({
+  messageId: z.string().describe("ID of the email message to delete"),
+});
+
+export const ListEmailLabelsSchema = z.object({}).describe("Retrieves all available Gmail labels");
+
+export const CreateLabelSchema = z.object({
+  name: z.string().describe("Name for the new label"),
+  messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+  labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Creates a new Gmail label");
+
+export const UpdateLabelSchema = z.object({
+  id: z.string().describe("ID of the label to update"),
+  name: z.string().optional().describe("New name for the label"),
+  messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+  labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Updates an existing Gmail label");
+
+export const DeleteLabelSchema = z.object({
+  id: z.string().describe("ID of the label to delete"),
+}).describe("Deletes a Gmail label");
+
+export const GetOrCreateLabelSchema = z.object({
+  name: z.string().describe("Name of the label to get or create"),
+  messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+  labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Gets an existing label by name or creates it if it doesn't exist");
+
+export const BatchModifyEmailsSchema = z.object({
+  messageIds: z.array(z.string()).describe("List of message IDs to modify"),
+  addLabelIds: z.array(z.string()).optional().describe("List of label IDs to add to all messages"),
+  removeLabelIds: z.array(z.string()).optional().describe("List of label IDs to remove from all messages"),
+  batchSize: z.number().optional().default(50).describe("Number of messages to process in each batch (default: 50)"),
+});
+
+export const BatchDeleteEmailsSchema = z.object({
+  messageIds: z.array(z.string()).describe("List of message IDs to delete"),
+  batchSize: z.number().optional().default(50).describe("Number of messages to process in each batch (default: 50)"),
+});
+
+export const CreateFilterSchema = z.object({
+  criteria: z.object({
+    from: z.string().optional().describe("Sender email address to match"),
+    to: z.string().optional().describe("Recipient email address to match"),
+    subject: z.string().optional().describe("Subject text to match"),
+    query: z.string().optional().describe("Gmail search query (e.g., 'has:attachment')"),
+    negatedQuery: z.string().optional().describe("Text that must NOT be present"),
+    hasAttachment: z.boolean().optional().describe("Whether to match emails with attachments"),
+    excludeChats: z.boolean().optional().describe("Whether to exclude chat messages"),
+    size: z.number().optional().describe("Email size in bytes"),
+    sizeComparison: z.enum(['unspecified', 'smaller', 'larger']).optional().describe("Size comparison operator")
+  }).describe("Criteria for matching emails"),
+  action: z.object({
+    addLabelIds: z.array(z.string()).optional().describe("Label IDs to add to matching emails"),
+    removeLabelIds: z.array(z.string()).optional().describe("Label IDs to remove from matching emails"),
+    forward: z.string().optional().describe("Email address to forward matching emails to")
+  }).describe("Actions to perform on matching emails")
+}).describe("Creates a new Gmail filter");
+
+export const ListFiltersSchema = z.object({}).describe("Retrieves all Gmail filters");
+
+export const GetFilterSchema = z.object({
+  filterId: z.string().describe("ID of the filter to retrieve")
+}).describe("Gets details of a specific Gmail filter");
+
+export const DeleteFilterSchema = z.object({
+  filterId: z.string().describe("ID of the filter to delete")
+}).describe("Deletes a Gmail filter");
+
+export const CreateFilterFromTemplateSchema = z.object({
+  template: z.enum(['fromSender', 'withSubject', 'withAttachments', 'largeEmails', 'containingText', 'mailingList']).describe("Pre-defined filter template to use"),
+  parameters: z.object({
+    senderEmail: z.string().optional().describe("Sender email (for fromSender template)"),
+    subjectText: z.string().optional().describe("Subject text (for withSubject template)"),
+    searchText: z.string().optional().describe("Text to search for (for containingText template)"),
+    listIdentifier: z.string().optional().describe("Mailing list identifier (for mailingList template)"),
+    sizeInBytes: z.number().optional().describe("Size threshold in bytes (for largeEmails template)"),
+    labelIds: z.array(z.string()).optional().describe("Label IDs to apply"),
+    archive: z.boolean().optional().describe("Whether to archive (skip inbox)"),
+    markAsRead: z.boolean().optional().describe("Whether to mark as read"),
+    markImportant: z.boolean().optional().describe("Whether to mark as important")
+  }).describe("Template-specific parameters")
+}).describe("Creates a filter using a pre-defined template");
+
+export const DownloadAttachmentSchema = z.object({
+  messageId: z.string().describe("ID of the email message containing the attachment"),
+  attachmentId: z.string().describe("ID of the attachment to download"),
+  filename: z.string().optional().describe("Filename to save the attachment as (if not provided, uses original filename)"),
+  savePath: z.string().optional().describe("Directory path to save the attachment (defaults to current directory)"),
+});
+
+// Tool definition type
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  schema: z.ZodType<any>;
+  scopes: string[]; // Any of these scopes grants access
+}
+
+// Tool registry with scope requirements
+export const toolDefinitions: ToolDefinition[] = [
+  // Read-only email operations
+  {
+    name: "read_email",
+    description: "Retrieves the content of a specific email",
+    schema: ReadEmailSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+  },
+  {
+    name: "search_emails",
+    description: "Searches for emails using Gmail search syntax",
+    schema: SearchEmailsSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+  },
+  {
+    name: "download_attachment",
+    description: "Downloads an email attachment to a specified location",
+    schema: DownloadAttachmentSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+  },
+
+  // Email write operations
+  {
+    name: "send_email",
+    description: "Sends a new email",
+    schema: SendEmailSchema,
+    scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+  },
+  {
+    name: "draft_email",
+    description: "Draft a new email",
+    schema: SendEmailSchema,
+    scopes: ["gmail.modify", "gmail.compose"],
+  },
+  {
+    name: "modify_email",
+    description: "Modifies email labels (move to different folders)",
+    schema: ModifyEmailSchema,
+    scopes: ["gmail.modify"],
+  },
+  {
+    name: "delete_email",
+    description: "Permanently deletes an email",
+    schema: DeleteEmailSchema,
+    scopes: ["gmail.modify"],
+  },
+  {
+    name: "batch_modify_emails",
+    description: "Modifies labels for multiple emails in batches",
+    schema: BatchModifyEmailsSchema,
+    scopes: ["gmail.modify"],
+  },
+  {
+    name: "batch_delete_emails",
+    description: "Permanently deletes multiple emails in batches",
+    schema: BatchDeleteEmailsSchema,
+    scopes: ["gmail.modify"],
+  },
+
+  // Label operations
+  {
+    name: "list_email_labels",
+    description: "Retrieves all available Gmail labels",
+    schema: ListEmailLabelsSchema,
+    scopes: ["gmail.readonly", "gmail.modify", "gmail.labels"],
+  },
+  {
+    name: "create_label",
+    description: "Creates a new Gmail label",
+    schema: CreateLabelSchema,
+    scopes: ["gmail.modify", "gmail.labels"],
+  },
+  {
+    name: "update_label",
+    description: "Updates an existing Gmail label",
+    schema: UpdateLabelSchema,
+    scopes: ["gmail.modify", "gmail.labels"],
+  },
+  {
+    name: "delete_label",
+    description: "Deletes a Gmail label",
+    schema: DeleteLabelSchema,
+    scopes: ["gmail.modify", "gmail.labels"],
+  },
+  {
+    name: "get_or_create_label",
+    description: "Gets an existing label by name or creates it if it doesn't exist",
+    schema: GetOrCreateLabelSchema,
+    scopes: ["gmail.modify", "gmail.labels"],
+  },
+
+  // Filter operations (require settings scope)
+  {
+    name: "list_filters",
+    description: "Retrieves all Gmail filters",
+    schema: ListFiltersSchema,
+    scopes: ["gmail.settings.basic"],
+  },
+  {
+    name: "get_filter",
+    description: "Gets details of a specific Gmail filter",
+    schema: GetFilterSchema,
+    scopes: ["gmail.settings.basic"],
+  },
+  {
+    name: "create_filter",
+    description: "Creates a new Gmail filter with custom criteria and actions",
+    schema: CreateFilterSchema,
+    scopes: ["gmail.settings.basic"],
+  },
+  {
+    name: "delete_filter",
+    description: "Deletes a Gmail filter",
+    schema: DeleteFilterSchema,
+    scopes: ["gmail.settings.basic"],
+  },
+  {
+    name: "create_filter_from_template",
+    description: "Creates a filter using a pre-defined template for common scenarios",
+    schema: CreateFilterFromTemplateSchema,
+    scopes: ["gmail.settings.basic"],
+  },
+];
+
+// Convert tool definitions to MCP tool format
+export function toMcpTools(tools: ToolDefinition[]) {
+  return tools.map(tool => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: zodToJsonSchema(tool.schema),
+  }));
+}
+
+// Get a tool definition by name
+export function getToolByName(name: string): ToolDefinition | undefined {
+  return toolDefinitions.find(t => t.name === name);
+}


### PR DESCRIPTION
This PR adds the ability to request only the OAuth scopes you need during authentication, which limits which tools are exposed to the LLM.

  Usage:
  # Read-only access (4 tools)
```bash
  npx @gongrzhe/server-gmail-autoauth-mcp auth --scopes=gmail.readonly
  ```

  # Full access (default, 18 tools)
```bash
  npx @gongrzhe/server-gmail-autoauth-mcp auth --scopes=gmail.modify,gmail.settings.basic
  ```
  Why: Reduces attack surface when you only need read access. The LLM won't even see tools it can't use.

  Changes:
  - New --scopes flag for auth command
  - Tools filtered at runtime based on authorized scopes
  - Backwards compatible with existing credentials